### PR TITLE
feat: Install iplike with the PostgreSQL database server

### DIFF
--- a/roles/opennms_core/defaults/main.yml
+++ b/roles/opennms_core/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-pg_version: 15
-
 opennms_distribution: Horizon
 opennms_version: 32.0.2
 opennms_pkg_version: "{{ opennms_version }}*"
@@ -19,7 +17,6 @@ iplike_version: 2
 iplike_pkg_version: "{{ iplike_version }}.*"
 
 opennms_pkgs:
-  - "iplike-pgsql{{ pg_version }}={{ iplike_pkg_version }}"
   - "jrrd2={{ jrrd2_pkg_version }}"
   - "opennms-common={{ opennms_pkg_version }}"
   - "opennms-server={{ opennms_pkg_version }}"

--- a/roles/opennms_core/tasks/main.yml
+++ b/roles/opennms_core/tasks/main.yml
@@ -1,7 +1,11 @@
 ---
-- name: Include OpenNMS Common roles
+- name: Include OpenNMS repository roles
   ansible.builtin.include_role:
-    name: opennms_common
+    name: opennms_repositories
+
+- name: Include OpenNMS OpenJDK roles
+  ansible.builtin.include_role:
+    name: opennms_openjdk
 
 - name: Include OpenNMS ICMP setup roles
   ansible.builtin.include_role:

--- a/roles/opennms_icmp/tasks/main.yml
+++ b/roles/opennms_icmp/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
-- name: Include OpenNMS Common roles
+- name: Include OpenNMS repository roles
   ansible.builtin.include_role:
-    name: opennms_common
+    name: opennms_repositories
 
 - name: Installing JICMP
   ansible.builtin.apt:

--- a/roles/opennms_kafka/tasks/main.yml
+++ b/roles/opennms_kafka/tasks/main.yml
@@ -1,13 +1,7 @@
 ---
-- name: Installing OpenJDK {{ openjdk_version }}
-  ansible.builtin.apt:
-    name: "openjdk-{{ openjdk_version }}-jdk-headless={{ openjdk_pkg_version }}"
-    state: present
-    install_recommends: false
-  tags:
-    - opennms
-    - kafka
-    - java
+- name: Include OpenNMS OpenJDK roles
+  ansible.builtin.include_role:
+    name: opennms_openjdk
 
 - name: Set java version to OpenJDK {{ openjdk_version }}
   community.general.alternatives:

--- a/roles/opennms_minion/tasks/main.yml
+++ b/roles/opennms_minion/tasks/main.yml
@@ -1,7 +1,11 @@
 ---
-- name: Include OpenNMS Common roles
+- name: Include OpenNMS OpenJDK roles
   ansible.builtin.include_role:
-    name: opennms_common
+    name: opennms_openjdk
+
+- name: Include OpenNMS repository roles
+  ansible.builtin.include_role:
+    name: opennms_repositories
 
 - name: Include OpenNMS ICMP setup roles
   ansible.builtin.include_role:

--- a/roles/opennms_openjdk/defaults/main.yml
+++ b/roles/opennms_openjdk/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# OpenJDK is a required for every component OpenNMS is running on and should be the same JDK version
+openjdk_version: 17
+openjdk_pkg_version: "{{ openjdk_version }}*"

--- a/roles/opennms_openjdk/tasks/main.yml
+++ b/roles/opennms_openjdk/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: Installing OpenJDK {{ openjdk_version }}
+  ansible.builtin.apt:
+    name: "openjdk-{{ openjdk_version }}-jdk-headless={{ openjdk_pkg_version }}"
+    state: present
+    install_recommends: false
+  tags:
+    - opennms
+    - java
+
+- name: Set java version to OpenJDK {{ openjdk_version }}
+  community.general.alternatives:
+    name: java
+    path: /usr/lib/jvm/java-{{ openjdk_version }}-openjdk-amd64/bin/java
+  tags:
+    - opennms
+    - java

--- a/roles/opennms_pgsql/defaults/main.yml
+++ b/roles/opennms_pgsql/defaults/main.yml
@@ -3,6 +3,7 @@ pgsql_key_url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
 pgsql_key_ring_file: /usr/share/keyrings/pgsql-keyring.gpg
 pgsql_repo_url: https://apt.postgresql.org/pub/repos/apt
 arch: amd64
+# Just the major version for PostgreSQL, used also for iplike installation and setup
 pg_version: 15
 pg_pkg_version: "{{ pg_version }}.*"
 

--- a/roles/opennms_pgsql/tasks/main.yml
+++ b/roles/opennms_pgsql/tasks/main.yml
@@ -8,6 +8,10 @@
     - dependency
     - ansible
 
+- name: Include OpenNMS repository roles
+  ansible.builtin.include_role:
+    name: opennms_repositories
+
 - name: Add PostgreSQL signing key to a keyring file
   ansible.builtin.apt_key:
     url: "{{ pgsql_key_url }}"
@@ -78,6 +82,14 @@
     - postgresql
     - ansible
 
+- name: Install OpenNMS iplike store package
+  ansible.builtin.apt:
+    name: iplike-pgsql{{ pg_version }}
+    state: present
+  tags:
+    - opennms
+    - postgresql
+
 - name: Set SCRAM-SHA-256 password encryption
   become_user: postgres
   community.postgresql.postgresql_set:
@@ -124,3 +136,15 @@
     - postgresql
     - initialize
     - database
+
+- name: Install iplike stored procedure in OpenNMS database
+  become_user: postgres
+  community.postgresql.postgresql_query:
+    db: "{{ opennms_datasource_db_name }}"
+    # yamllint disable-line rule:line-length
+    query: "CREATE OR REPLACE FUNCTION iplike(i_ipaddress text,i_rule text) RETURNS bool AS '/usr/lib/postgresql/{{ pg_version }}/lib/iplike.so' LANGUAGE 'c' RETURNS NULL ON NULL INPUT;"
+  tags:
+    - opennms
+    - postgresql
+    - iplike
+    - credentials

--- a/roles/opennms_repositories/defaults/main.yml
+++ b/roles/opennms_repositories/defaults/main.yml
@@ -1,8 +1,4 @@
 ---
-# OpenJDK is a required for every component OpenNMS is running on and should be the same JDK version
-openjdk_version: 17
-openjdk_pkg_version: "{{ openjdk_version }}*"
-
 # Specify the OpenNMS version.
 # Pick a very specific version cause we can't handle updates automatically.
 arch: amd64

--- a/roles/opennms_repositories/tasks/main.yml
+++ b/roles/opennms_repositories/tasks/main.yml
@@ -32,17 +32,3 @@
   tags:
     - opennms
     - repository
-
-- name: Installing OpenJDK {{ openjdk_version }}
-  ansible.builtin.apt:
-    name: "openjdk-{{ openjdk_version }}-jdk-headless={{ openjdk_pkg_version }}"
-    state: present
-    install_recommends: false
-  tags:
-    - opennms
-    - java
-
-- name: Set java version to OpenJDK {{ openjdk_version }}
-  community.general.alternatives:
-    name: java
-    path: /usr/lib/jvm/java-{{ openjdk_version }}-openjdk-amd64/bin/java

--- a/roles/opennms_sentinel/tasks/main.yml
+++ b/roles/opennms_sentinel/tasks/main.yml
@@ -1,7 +1,11 @@
 ---
-- name: Include OpenNMS Common roles
+- name: Include OpenNMS OpenJDK roles
   ansible.builtin.include_role:
-    name: opennms_common
+    name: opennms_openjdk
+
+- name: Include OpenNMS repository roles
+  ansible.builtin.include_role:
+    name: opennms_repositories
 
 - name: Installing OpenNMS Sentinel
   ansible.builtin.apt:


### PR DESCRIPTION
Install the iplike stored procedure with the PostgreSQL server. The iplike stored procedure needs to be installed from the OpenNMS package repository. Instead of using the installer script the function is using the Ansible builtin query functions so we can use variables for database names and accordingly.

Resolves: #7