### PR TITLE
chg: Bump from 33.0.1 to 33.0.2

### DIFF
--- a/roles/opennms_core/defaults/main.yml
+++ b/roles/opennms_core/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 opennms_distribution: Horizon
-opennms_version: 33.0.1
+opennms_version: 33.0.2
 opennms_pkg_version: "{{ opennms_version }}*"
 
 opennms_plugin_cloud_version: 1

--- a/roles/opennms_minion/defaults/main.yml
+++ b/roles/opennms_minion/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 opennms_distribution: Horizon
-opennms_version: 33.0.1
+opennms_version: 33.0.2
 opennms_pkg_version: "{{ opennms_version }}*"
 opennms_minion_home: "/usr/share/minion"
 

--- a/roles/opennms_sentinel/defaults/main.yml
+++ b/roles/opennms_sentinel/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 opennms_distribution: Horizon
-opennms_version: 33.0.1
+opennms_version: 33.0.2
 opennms_pkg_version: "{{ opennms_version }}*"
 opennms_sentinel_home: /usr/share/sentinel
 


### PR DESCRIPTION
There are packaging issues for 33.0.1.

![image](https://github.com/opennms-forge/ansible-opennms/assets/4995222/62112871-85fb-4430-a7a5-a191a6e120d8)


I tried 33.0.2 and the installation worked. So I bumped the versions.