### PR TITLE
chore: upgrade OpenNMS Horizon to 35.0.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ ansible-playbook -i inventory/opennms-stack.yml hzn-sentinel-deployment.yml
 - `opennms_repositories` — APT repo and GPG key setup; must run before any package install
 - `openjdk` — Installs OpenJDK 17 for OpenNMS components and OpenJDK 21 for Kafka
 - `common` — Timezone, APT cache update, base system packages
-- `opennms_core` — OpenNMS Horizon Core (35.0.4): database init, Kafka config, JVM tuning, firewall rules
+- `opennms_core` — OpenNMS Horizon Core (35.0.5): database init, Kafka config, JVM tuning, firewall rules
 - `opennms_minion` — Minion agent for isolated network segments
 - `opennms_sentinel` — Flow persistence and aggregation
 - `opennms_icmp` — ICMP monitoring configuration
@@ -105,7 +105,7 @@ External collections (`requirements.yml`):
 
 | Component | Version |
 |-----------|---------|
-| OpenNMS Horizon | 35.0.4 |
+| OpenNMS Horizon | 35.0.5 |
 | PostgreSQL | 15 |
 | Kafka | 4.2.0 (KRaft) |
 | OpenJDK | 17 |

--- a/roles/opennms_core/defaults/main.yml
+++ b/roles/opennms_core/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 opennms_distribution: Horizon
-opennms_version: 35.0.4
+opennms_version: 35.0.5
 opennms_pkg_version: "{{ opennms_version }}*"
 
 opennms_home: /opt/opennms

--- a/roles/opennms_minion/defaults/main.yml
+++ b/roles/opennms_minion/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 opennms_distribution: Horizon
-opennms_version: 35.0.4
+opennms_version: 35.0.5
 opennms_pkg_version: "{{ opennms_version }}*"
 opennms_minion_home: "/opt/minion"
 

--- a/roles/opennms_sentinel/defaults/main.yml
+++ b/roles/opennms_sentinel/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 opennms_distribution: Horizon
-opennms_version: 35.0.4
+opennms_version: 35.0.5
 opennms_pkg_version: "{{ opennms_version }}*"
 opennms_sentinel_home: /opt/sentinel
 


### PR DESCRIPTION
## Summary

- Bump `opennms_version` from `35.0.4` to `35.0.5` in `opennms_core`, `opennms_minion`, and `opennms_sentinel` role defaults
- Update version table in `CLAUDE.md`

## Test plan

- [ ] Verify `ansible-lint` passes in CI
- [ ] Deploy to a test host and confirm the correct package version is installed for core, minion, and sentinel

🤖 Generated with [Claude Code](https://claude.com/claude-code)