### PR TITLE
fix(opennms_repositories): migrate APT repo to debian.opennms.org

### DIFF
--- a/roles/opennms_repositories/defaults/main.yml
+++ b/roles/opennms_repositories/defaults/main.yml
@@ -3,8 +3,7 @@
 # Pick a very specific version cause we can't handle updates automatically.
 arch: amd64
 
-opennms_key_url: https://packages.opennms.com/public/stable/gpg.697677243260D071.key
-opennms_key_sha256: f2396a3fdf52777892c5bf72839f7cd81bd026b3a26a920438c7f9a1e4f1b19b
+opennms_key_url: https://debian.opennms.org/OPENNMS-GPG-KEY
+opennms_key_sha256: 8383524acbcbe8cf860259fe8c4184c355bfd0c6350b6852534df8dbfbe8c406
 opennms_key_ring_file: /usr/share/keyrings/opennms-stable-archive-keyring.gpg
-opennms_repo_url: https://packages.opennms.com/public/stable/deb/ubuntu
-opennms_common_repo_url: https://packages.opennms.com/public/common/deb/ubuntu
+opennms_repo_url: https://debian.opennms.org

--- a/roles/opennms_repositories/tasks/main.yml
+++ b/roles/opennms_repositories/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Download OpenNMS repository key
   ansible.builtin.get_url:
     url: "{{ opennms_key_url }}"
-    dest: /tmp/gpg.697677243260D071.key
+    dest: /tmp/opennms-repo.key
     mode: "0644"
     checksum: "sha256:{{ opennms_key_sha256 }}"
   tags:
@@ -10,7 +10,7 @@
     - repository
 
 - name: Convert the OpenNMS repository key to GPG format
-  ansible.builtin.command: "gpg --dearmor -o {{ opennms_key_ring_file }} /tmp/gpg.697677243260D071.key"
+  ansible.builtin.command: "gpg --dearmor -o {{ opennms_key_ring_file }} /tmp/opennms-repo.key"
   args:
     creates: "{{ opennms_key_ring_file }}"
   register: opennms_key_ring
@@ -21,16 +21,7 @@
 
 - name: Install OpenNMS APT repository for stable releases
   ansible.builtin.apt_repository:
-    repo: "deb [arch={{ arch }} signed-by={{ opennms_key_ring_file }}] {{ opennms_repo_url }} {{ ansible_distribution_release }} main"
-    state: present
-    update_cache: true
-  tags:
-    - opennms
-    - repository
-
-- name: Install OpenNMS APT commons repository
-  ansible.builtin.apt_repository:
-    repo: "deb [arch={{ arch }} signed-by={{ opennms_key_ring_file }}] {{ opennms_common_repo_url }} {{ ansible_distribution_release }} main"
+    repo: "deb [arch={{ arch }} signed-by={{ opennms_key_ring_file }}] {{ opennms_repo_url }} stable main"
     state: present
     update_cache: true
   tags:

--- a/roles/opennms_repositories/tasks/main.yml
+++ b/roles/opennms_repositories/tasks/main.yml
@@ -10,11 +10,18 @@
     - repository
 
 - name: Convert the OpenNMS repository key to GPG format
-  ansible.builtin.command: "gpg --dearmor -o {{ opennms_key_ring_file }} /tmp/opennms-repo.key"
-  args:
-    creates: "{{ opennms_key_ring_file }}"
-  register: opennms_key_ring
-  changed_when: opennms_key_ring.rc != 0
+  ansible.builtin.command: "gpg --dearmor -o /tmp/opennms-repo-keyring.gpg /tmp/opennms-repo.key"
+  changed_when: false
+  tags:
+    - opennms
+    - repository
+
+- name: Install OpenNMS repository keyring
+  ansible.builtin.copy:
+    src: /tmp/opennms-repo-keyring.gpg
+    dest: "{{ opennms_key_ring_file }}"
+    mode: "0644"
+    remote_src: true
   tags:
     - opennms
     - repository


### PR DESCRIPTION
## Summary

- Replaces `packages.opennms.com` with `https://debian.opennms.org` as the APT repository source
- Updates the GPG key URL to `https://debian.opennms.org/OPENNMS-GPG-KEY` with its SHA256 checksum
- Switches the distribution suite from the Ubuntu release codename to `stable`
- Removes the common repository (no longer required with the new repo)
- Renames the temporary key file from `gpg.697677243260D071.key` to `opennms-repo.key`

## Test plan

- [ ] Run `opennms_repositories` role against a clean Ubuntu host and verify packages install from `debian.opennms.org`
- [ ] Confirm GPG key checksum passes
- [ ] Verify `opennms-stable-archive-keyring.gpg` is created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)