### PR TITLE
fix(opennms_repositories): add --batch --yes to gpg dearmor to avoid /dev/tty

### DIFF
--- a/roles/opennms_repositories/tasks/main.yml
+++ b/roles/opennms_repositories/tasks/main.yml
@@ -10,7 +10,7 @@
     - repository
 
 - name: Convert the OpenNMS repository key to GPG format
-  ansible.builtin.command: "gpg --dearmor -o /tmp/opennms-repo-keyring.gpg /tmp/opennms-repo.key"
+  ansible.builtin.command: "gpg --batch --yes --dearmor -o /tmp/opennms-repo-keyring.gpg /tmp/opennms-repo.key"
   changed_when: false
   tags:
     - opennms


### PR DESCRIPTION
## Summary

- Adds `--batch --yes` to the `gpg --dearmor` command in `opennms_repositories`
- Without `--batch`, gpg tries to open `/dev/tty` for interactive prompts even during a simple dearmor operation, which fails over SSH in Ansible runs
- `--yes` ensures the output file is overwritten without prompting if it already exists

## Test plan

- [ ] Run the `opennms_repositories` role against a fresh host and verify the keyring is installed without error
- [ ] Run against a host where `/tmp/opennms-repo-keyring.gpg` already exists and verify it is overwritten cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)