### PR TITLE
fix(opennms_core): deploy postgres version compat property before install -dis

### DIFF
--- a/roles/opennms_core/tasks/10-database-setup.yml
+++ b/roles/opennms_core/tasks/10-database-setup.yml
@@ -34,6 +34,18 @@
     - initialize
     - credentials
 
+- name: Configure PostgreSQL version compatibility
+  ansible.builtin.template:
+    src: etc/opennms.properties.d/_ansible.postgres.properties.j2
+    dest: "{{ opennms_home }}/etc/opennms.properties.d/_ansible.postgres.properties"
+    owner: opennms
+    group: opennms
+    mode: "0640"
+  tags:
+    - opennms
+    - initialize
+    - database
+
 - name: Verify if database is already initialized
   ansible.builtin.stat:
     path: "{{ opennms_home }}/etc/configured"


### PR DESCRIPTION
## Problem

`_ansible.postgres.properties.j2` sets `opennms.postgresql.maxVersion` to `{{ pg_version + 1 }}.0`, which is intended to allow the OpenNMS installer to accept PostgreSQL versions newer than the hardcoded `< 17.0` gate.

However the template was **never deployed** — no task in any role file referenced it. As a result, `install -dis` reads no override and rejects PostgreSQL 17+:

```
MigrationException: Unsupported database version "18.299999" -- you need at
least 10.000000 and less than 17.000000.
```

A second problem: even if the task had been placed in `20-config.yml`, it would still fail because `main.yml` runs `10-database-setup.yml` (which calls `install -dis`) **before** `20-config.yml`.

## Fix

Add a `Configure PostgreSQL version compatibility` task to `10-database-setup.yml`, immediately before the schema init task. This ensures the property file is written to `opennms.properties.d/` before `install -dis` reads it.

For PostgreSQL 18 this renders `opennms.postgresql.maxVersion=19.0`, clearing the version gate.

## Test plan

- [ ] Fresh deployment with `stub_pgsql` (PostgreSQL 18) completes `install -dis` without version error
- [ ] `_ansible.postgres.properties` is present in `/opt/opennms/etc/opennms.properties.d/` after the database-setup tasks run
- [ ] Re-runs (when `etc/configured` already exists) are idempotent — template task still converges without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)