### PR TITLE
fix(opennms_core): add pg_version default to avoid undefined variable

### DIFF
--- a/roles/opennms_core/defaults/main.yml
+++ b/roles/opennms_core/defaults/main.yml
@@ -51,6 +51,8 @@ opennms_perl_deps:
   - libwww-perl
   - libxml-twig-perl
 
+pg_version: 18
+
 opennms_datasource_db_host: localhost
 opennms_datasource_db_port: 5432
 opennms_datasource_db_name: opennms_horizon


### PR DESCRIPTION
## Summary

- `opennms_core` uses `pg_version` in its postgres version compatibility template but had no default of its own — it relied on the variable being set by `stub_pgsql`
- In distributed topologies where PostgreSQL runs on a separate host, `stub_pgsql` is not co-located with `opennms_core`, so `pg_version` is undefined and the play fails
- Adds `pg_version: 18` to `opennms_core/defaults/main.yml` so the role is self-contained; callers can still override it

## Test plan

- [ ] Deploy `opennms_core` against an external PostgreSQL host (without `stub_pgsql` on the same host) and verify the play completes without `'pg_version' is undefined`
- [ ] Verify `opennms.properties.d/_ansible.postgres.properties` contains `opennms.postgresql.maxVersion=19.0`
- [ ] Verify existing single-host deployments (where `stub_pgsql` runs co-located) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)