### PR TITLE
fix(opennms_core): pass pg max version via ADDITIONAL_MANAGER_OPTIONS at install time

### DIFF
--- a/roles/opennms_core/tasks/10-database-setup.yml
+++ b/roles/opennms_core/tasks/10-database-setup.yml
@@ -55,6 +55,8 @@
   become: true
   become_user: opennms
   ansible.builtin.command: "{{ opennms_home }}/bin/install -dis"
+  environment:
+    ADDITIONAL_MANAGER_OPTIONS: "-Dopennms.postgresql.maxVersion={{ (pg_version | int + 1) }}.0"
   register: database_init
   when: not initialized_schema.stat.exists
   changed_when: database_init.rc != 0


### PR DESCRIPTION
## Summary

- The `install -dis` command never reads `opennms.properties.d/` — `Bootstrap.loadSystemProperties()` (which loads that directory) is only invoked *after* the database migration completes
- The `opennms.postgresql.maxVersion` property written by `_ansible.postgres.properties.j2` was therefore invisible to `Migrator.validateDatabaseVersion()`, which kept enforcing its hard-coded default limit of `17.0`
- Fix by passing `-Dopennms.postgresql.maxVersion` as a JVM system property via `ADDITIONAL_MANAGER_OPTIONS`, which the install wrapper script forwards to the JVM before the `Migrator` class is loaded and its `static final` field is frozen

## Root cause detail

`Migrator.java` reads the max version as a `static final` field at class-load time:
```java
private static final float POSTGRESQL_MAX_VERSION_EXCLUSIVE =
    Float.parseFloat(System.getProperty("opennms.postgresql.maxVersion", "17.0"));
```

`Installer.loadProperties()` only reads `opennms.properties` and `rrd-configuration.properties` — never `opennms.properties.d/`. `Bootstrap.loadSystemProperties()` (which does load `opennms.properties.d/`) is called at the very end of the install run, after `validateDatabaseVersion()` has already fired.

## Test plan

- [ ] Deploy stack with `pg_version: 18` — `install -dis` should complete without the `Unsupported database version` error
- [ ] Verify `opennms.service` starts successfully after schema init

🤖 Generated with [Claude Code](https://claude.com/claude-code)