### PR TITLE
fix(grafana): bump grafana_version to 13.0.1

### DIFF
--- a/group_vars/grafana/vars.yml
+++ b/group_vars/grafana/vars.yml
@@ -1,7 +1,7 @@
 ---
 # Grafana version — must be an exact version string or "latest"
 # grafana.grafana collection constructs the apt package as grafana=<version>
-grafana_version: "12.4.2"
+grafana_version: "13.0.1"
 
 # Repo management is handled automatically by the collection
 grafana_manage_repo: true


### PR DESCRIPTION
## Summary
- Bumps `grafana_version` in `group_vars/grafana/vars.yml` from `12.4.2` to `13.0.1`.
- Fresh deploys were failing on `mon-*` hosts: the grafana apt repo's current stable (`13.0.1`) is newer than the pin, and the `grafana.grafana.grafana` role's install step runs `apt-get -y install grafana=12.4.2`, which apt rejects with `E: Packages were downgraded and -y was used without --allow-downgrades`.
- `13.0.1` matches what the public grafana apt repo currently serves as stable, restoring clean installs.

## Test plan
- [x] Reproduced the failure on a fresh KVM deploy (exit 100 on the install task).
- [x] Applied the bump and re-ran the full `deploy.sh --provider kvm` — step 3/3 completed with `failed=0` across all hosts.
- [x] CI lint passes.

> Note: this PR was prepared with AI assistance; the human submitter is responsible for reviewing and adding a `Signed-off-by` DCO trailer before merge.