### PR TITLE
fix(grafana): pin grafana_version to 12.4.3 pending Grafana 13 plugin fix

### DIFF
--- a/group_vars/grafana/vars.yml
+++ b/group_vars/grafana/vars.yml
@@ -1,7 +1,10 @@
 ---
 # Grafana version — must be an exact version string or "latest"
 # grafana.grafana collection constructs the apt package as grafana=<version>
-grafana_version: "13.0.1"
+# Pinned to 12.x: Grafana 13 breaks the collection's plugin install task
+# (grafana-cli needs --homepath). Bump back to 13.x once upstream fixes this.
+# See: https://github.com/grafana/grafana-ansible-collection/issues/497
+grafana_version: "12.4.3"
 
 # Repo management is handled automatically by the collection
 grafana_manage_repo: true


### PR DESCRIPTION
## Summary

- Revert `grafana_version` from `13.0.1` → `12.4.3` (latest 12.x).
- Add a comment linking the upstream tracking issue so future bumps have context.

## Why

Grafana 13 changed `grafana-cli` so it now requires `--homepath /usr/share/grafana` (or the working directory set to it), and flags the whole command as deprecated in favour of the new `grafana cli` subcommand.

`grafana.grafana` collection v6.0.6 (the version pinned in `requirements.yml`) still drives plugin installs via bare `grafana-cli ... plugins install`, so on 13.x it fails with:

```
Grafana-server Init Failed: Could not find config defaults, make sure
homepath command line parameter is set or working directory is homepath
```

Reproduced on a fresh KVM lab deploy of the opennms-benchmark stack — bootstrap succeeded but the OpenNMS playbook failed at `grafana.grafana.grafana : Install plugins` installing `opennms-opennms-app`.

## Follow-up

- Upstream tracking: grafana/grafana-ansible-collection#497
- Once the collection handles the new CLI contract (or we bump the collection to a release that does), bump this pin back to 13.x.

## Test plan

- [ ] Re-run `./deploy.sh --provider kvm` against a clean lab — expect the grafana role and plugin install to complete without the `homepath` error.
- [ ] Confirm Grafana UI loads and the `opennms-opennms-app` plugin is present.

## DCO

This commit was AI-assisted (`Assisted-by: Claude Code:claude-opus-4-7`) and is **not** signed off yet. Per the DCO, the human submitter needs to add a `Signed-off-by` trailer before merge — either amend locally with `git commit -s --amend` and force-push, or use GitHub's "Add sign-off" option at merge time.