### PR TITLE
fix(opennms_minion): allow inbound syslog on 10514/udp

### DIFF
--- a/roles/opennms_minion/tasks/50-firewall.yml
+++ b/roles/opennms_minion/tasks/50-firewall.yml
@@ -8,6 +8,15 @@
     - opennms
     - firewall
 
+- name: Allow all receiving syslog messages on port 10514/udp
+  community.general.ufw:
+    rule: allow
+    port: '10514'
+    proto: udp
+  tags:
+    - opennms
+    - firewall
+
 - name: Allow all receiving NetFlow protocols on single-port listener on port 9999/udp
   community.general.ufw:
     rule: allow


### PR DESCRIPTION
## Summary

- Add a UFW rule to the `opennms_minion` firewall tasks that allows inbound UDP on port `10514`.
- The role already opens `10162/udp` (SNMP traps) and `9999/udp` (NetFlow single-port listener) but was missing syslog.
- Without this rule, syslog traffic targeted at the Minion's default listener — including the streams emitted by the [`l8opensim`](https://github.com/labmonkeys-space/l8opensim) simulator's `-syslog-collector` flag — is silently dropped by UFW on the Minion VM.

Surfaced while wiring SNMP-trap + syslog collectors through `l8opensim` v0.4.1 in the downstream benchmark lab (see [indigo423/opennms-benchmark#101](https://github.com/indigo423/opennms-benchmark/pull/101)); the trap port worked out of the box, syslog did not, because this rule was missing.

## Test plan

- [ ] `ansible-lint` passes on `roles/opennms_minion/tasks/50-firewall.yml` (production profile)
- [ ] Run `hzn-minion-deployment.yml` against a Minion VM and confirm `ufw status` lists `10514/udp ALLOW`
- [ ] Send a test syslog datagram from another host (e.g. `logger -n <minion> -P 10514 -d test`) and confirm it is not dropped