### PR TITLE
feat: upgrade OpenNMS Horizon to 36.0.0 and OpenJDK to 21

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ ansible-playbook -i inventory/opennms-stack.yml hzn-sentinel-deployment.yml
 
 **Core OpenNMS components** (production targets):
 - `opennms_repositories` — APT repo and GPG key setup; must run before any package install
-- `openjdk` — Installs OpenJDK 17 for OpenNMS components and OpenJDK 21 for Kafka
+- `openjdk` — Installs OpenJDK 21 for OpenNMS components and Kafka
 - `common` — Timezone, APT cache update, base system packages
 - `opennms_core` — OpenNMS Horizon Core (35.0.5): database init, Kafka config, JVM tuning, firewall rules
 - `opennms_minion` — Minion agent for isolated network segments
@@ -108,7 +108,7 @@ External collections (`requirements.yml`):
 | OpenNMS Horizon | 35.0.5 |
 | PostgreSQL | 18 |
 | Kafka | 4.2.0 (KRaft) |
-| OpenJDK | 17 |
+| OpenJDK | 21 |
 | Grafana | 12.x |
 | Grafana Mimir | 3.0.4 |
 | Prometheus JMX Exporter | 1.5.0 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ ansible-playbook -i inventory/opennms-stack.yml hzn-sentinel-deployment.yml
 - `opennms_repositories` — APT repo and GPG key setup; must run before any package install
 - `openjdk` — Installs OpenJDK 21 for OpenNMS components and Kafka
 - `common` — Timezone, APT cache update, base system packages
-- `opennms_core` — OpenNMS Horizon Core (35.0.5): database init, Kafka config, JVM tuning, firewall rules
+- `opennms_core` — OpenNMS Horizon Core (36.0.0): database init, Kafka config, JVM tuning, firewall rules
 - `opennms_minion` — Minion agent for isolated network segments
 - `opennms_sentinel` — Flow persistence and aggregation
 - `opennms_icmp` — ICMP monitoring configuration
@@ -105,7 +105,7 @@ External collections (`requirements.yml`):
 
 | Component | Version |
 |-----------|---------|
-| OpenNMS Horizon | 35.0.5 |
+| OpenNMS Horizon | 36.0.0 |
 | PostgreSQL | 18 |
 | Kafka | 4.2.0 (KRaft) |
 | OpenJDK | 21 |

--- a/roles/openjdk/defaults/main.yml
+++ b/roles/openjdk/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-openjdk_version: 17
+openjdk_version: 21
 openjdk_pkg_version: "{{ openjdk_version }}*"

--- a/roles/opennms_core/defaults/main.yml
+++ b/roles/opennms_core/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 opennms_distribution: Horizon
-opennms_version: 35.0.5
+opennms_version: 36.0.0
 opennms_pkg_version: "{{ opennms_version }}*"
 
 opennms_home: /opt/opennms

--- a/roles/opennms_core/tasks/main.yml
+++ b/roles/opennms_core/tasks/main.yml
@@ -3,8 +3,8 @@
   ansible.builtin.include_role:
     name: openjdk
   vars:
-    openjdk_version: 17
-    openjdk_pkg_version: "17*"
+    openjdk_version: 21
+    openjdk_pkg_version: "21*"
 
 - name: Include OpenNMS repository roles
   ansible.builtin.include_role:

--- a/roles/opennms_minion/defaults/main.yml
+++ b/roles/opennms_minion/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 opennms_distribution: Horizon
-opennms_version: 35.0.5
+opennms_version: 36.0.0
 opennms_pkg_version: "{{ opennms_version }}*"
 opennms_minion_home: "/opt/minion"
 

--- a/roles/opennms_minion/tasks/main.yml
+++ b/roles/opennms_minion/tasks/main.yml
@@ -3,8 +3,8 @@
   ansible.builtin.include_role:
     name: openjdk
   vars:
-    openjdk_version: 17
-    openjdk_pkg_version: "17*"
+    openjdk_version: 21
+    openjdk_pkg_version: "21*"
 
 - name: Include OpenNMS repository roles
   ansible.builtin.include_role:

--- a/roles/opennms_sentinel/defaults/main.yml
+++ b/roles/opennms_sentinel/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 opennms_distribution: Horizon
-opennms_version: 35.0.5
+opennms_version: 36.0.0
 opennms_pkg_version: "{{ opennms_version }}*"
 opennms_sentinel_home: /opt/sentinel
 

--- a/roles/opennms_sentinel/tasks/main.yml
+++ b/roles/opennms_sentinel/tasks/main.yml
@@ -3,8 +3,8 @@
   ansible.builtin.include_role:
     name: openjdk
   vars:
-    openjdk_version: 17
-    openjdk_pkg_version: "17*"
+    openjdk_version: 21
+    openjdk_pkg_version: "21*"
 
 - name: Include OpenNMS repository roles
   ansible.builtin.include_role:


### PR DESCRIPTION
## Summary

- Bumps `opennms_version` from `35.0.5` to `36.0.0` in the `opennms_core`, `opennms_minion`, and `opennms_sentinel` role defaults.
- Bumps the `openjdk_version` override from `17` to `21` in the same three roles, and flips the `openjdk` role default to `21` so future callers stay aligned.
- Horizon 36.0.0's dpkg postinst aborts when only OpenJDK 17 is present (it searches for `java-21` and falls back to suggesting `apt-get install openjdk-21-jdk`); the two changes are functionally inseparable and ship together here.
- Refreshes the stale `35.0.5` and `OpenJDK 17` mentions in `CLAUDE.md` (role description and Key Versions table).

## Test plan

- [ ] Deploy a Horizon 36.0.0 single-node stack against a fresh Ubuntu LTS host and confirm `opennms.service` reaches `active (running)`.
- [ ] Deploy a Minion 36.0.0 against the same stack and confirm `minion.service` reaches `active (running)`.
- [ ] Deploy a Sentinel 36.0.0 against the same stack and confirm `sentinel.service` reaches `active (running)`.
- [ ] Re-run the playbook to confirm idempotency (no JDK or OpenNMS package churn on second pass).
- [ ] `ansible-lint` clean against the `production` profile.

## Notes for upgraders

Hosts that previously attempted to install Horizon 36 with only JDK 17 present will have `opennms-server` in a half-configured (`iU`) state. After this PR lands, install JDK 21 first, then run `sudo dpkg --configure -a` to let the postinst finish — or `apt-get install --reinstall opennms-server=36.0.0-1`.