### PR TITLE
feat(ci): add Ansible Galaxy publish pipeline for indigo423.opennms

### DIFF
--- a/.github/workflows/galaxy-release.yml
+++ b/.github/workflows/galaxy-release.yml
@@ -1,0 +1,38 @@
+---
+name: galaxy-release
+run-name: Publish collection to Ansible Galaxy
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.13'
+      - name: Install ansible-core
+        run: pip install ansible-core==2.20.4
+      - name: Verify galaxy.yml version matches release tag
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          EXPECTED="${TAG#v}"
+          ACTUAL=$(awk '/^version:/ { print $2 }' galaxy.yml | tr -d '"' | tr -d "'")
+          if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+            echo "::error::galaxy.yml version (${ACTUAL}) does not match release tag (${TAG} -> ${EXPECTED}). Bump galaxy.yml before tagging."
+            exit 1
+          fi
+      - name: Build collection
+        run: ansible-galaxy collection build --output-path dist/
+      - name: Publish collection to Ansible Galaxy
+        env:
+          GALAXY_TOKEN: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
+        run: |
+          ansible-galaxy collection publish \
+            --token "${GALAXY_TOKEN}" \
+            dist/indigo423-opennms-*.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to the `indigo423.opennms` collection are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each entry below is a short index; the corresponding GitHub release contains the full notes including the Component Versions table and upgrade instructions.
+
+## [0.3.0] - 2026-05-25
+
+### Changed
+- Bump OpenNMS Horizon from `35.0.5` to `36.0.0` for the `opennms_core`, `opennms_minion`, and `opennms_sentinel` roles.
+- Bump OpenJDK from `17` to `21` across all OpenNMS roles (Horizon 36's dpkg postinst fails on JDK 17). The `openjdk` role default also flips to `21`.
+- Bump the `grafana.grafana` collection to `6.1.0` and `community.general` to `12.6.0`.
+
+### Fixed
+- `opennms_minion`: allow inbound syslog on `10514/udp` (#82).
+- `grafana`: pin `grafana_version` to `12.4.3` pending the upstream Grafana 13 plugin-install fix (#81). Tracks https://github.com/grafana/grafana-ansible-collection/issues/497.
+
+## [0.2.0] - 2026-04-17
+
+### Changed
+- `grafana`: bump `grafana_version` from `12.4.2` to `13.0.1` (#80) to track the upstream APT repo's current stable.
+
+## [0.1.0] - 2026-04-10
+
+### Added
+- Initial release of the collection. Deploys OpenNMS Horizon Core, Minion, and Sentinel on Debian/Ubuntu, with stub roles for PostgreSQL, Kafka, Elasticsearch, and Grafana Mimir.
+- Grafana integration via the upstream `grafana.grafana` collection plus an `opennms-opennms-app` provisioning role (replaces the prior `stub_grafana` role).
+- `opennms_repositories` migrated to `debian.opennms.org` with non-interactive GPG dearmor.
+- Per-role JDK pinning to prevent `include_role` variable bleed.
+- Renovate configuration for automated Ansible Galaxy collection updates.
+- CI on standard GitHub-hosted runners with SHA-pinned actions and Dependabot.
+
+[0.3.0]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.3.0
+[0.2.0]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.2.0
+[0.1.0]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.1.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -125,16 +125,20 @@ The collection is published to Ansible Galaxy as **`indigo423.opennms`**. Public
 1. **Namespace ownership.** The `indigo423` namespace on https://galaxy.ansible.com must be owned (or co-owned) by the account that generates the API token. New collaborators are added via the *Namespaces* page on galaxy.ansible.com.
 2. **API token.** Generate a token at https://galaxy.ansible.com/me/preferences (Preferences → API Key) and store it as the `ANSIBLE_GALAXY_API_KEY` secret under *Settings → Secrets and variables → Actions* for the repo. The token belongs to the user; if it rotates, update the secret.
 
-### Per-release: bump `galaxy.yml`
+### Per-release: bump `galaxy.yml` and update `CHANGELOG.md`
 
-Before tagging a release, bump the `version:` field in `galaxy.yml` to match the intended tag (without the `v` prefix):
+Before tagging a release, two files must be updated in the same PR that bumps role defaults and `CLAUDE.md`'s Component Versions table:
 
-```yaml
-# galaxy.yml
-version: 0.4.0   # matches the upcoming v0.4.0 tag
-```
+1. **`galaxy.yml`** — set `version:` to match the intended tag (without the `v` prefix):
 
-Include this bump in the same PR that updates role defaults and `CLAUDE.md`'s Component Versions table. The release workflow verifies `galaxy.yml`'s `version` equals `<release-tag>` minus the `v` and fails the build otherwise — this guard catches forgotten bumps before the artifact ships.
+   ```yaml
+   # galaxy.yml
+   version: 0.4.0   # matches the upcoming v0.4.0 tag
+   ```
+
+   The release workflow verifies `galaxy.yml`'s `version` equals `<release-tag>` minus the `v` and fails the build otherwise — this guard catches forgotten bumps before the artifact ships.
+
+2. **`CHANGELOG.md`** — add a new `## [X.Y.Z] - YYYY-MM-DD` section at the top with short entries grouped by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Update the link-reference list at the bottom. The file is required by the `galaxy[no-changelog]` ansible-lint rule and is shipped inside the published artifact.
 
 ### Release flow with Galaxy
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,167 @@
+# Releasing
+
+This document describes how to cut a release of `ansible-opennms`.
+
+## Versioning
+
+Releases follow [Semantic Versioning](https://semver.org/) with tags in the form `vMAJOR.MINOR.PATCH`.
+
+- **MAJOR** — incompatible role or variable changes (e.g., renamed/removed defaults, removed roles, changed playbook entry points).
+- **MINOR** — new roles, new opt-in features, or coordinated upstream version bumps that require user action (e.g., Horizon major version, JDK major version).
+- **PATCH** — bug fixes and upstream version pins that don't change the user-facing contract.
+
+While the project is `v0.x`, breaking changes may land in MINOR bumps; flag them clearly in the release notes under an `### Breaking Changes` heading.
+
+## Where component versions live
+
+When preparing a release, check these files for any version drift that should be reflected in the release notes:
+
+| Component | File |
+|-----------|------|
+| OpenNMS Horizon | `roles/opennms_core/defaults/main.yml`, `roles/opennms_minion/defaults/main.yml`, `roles/opennms_sentinel/defaults/main.yml` (`opennms_version`) |
+| OpenJDK | `roles/openjdk/defaults/main.yml` (`openjdk_version`) and per-role overrides in `roles/opennms_*/tasks/main.yml` |
+| PostgreSQL | `roles/opennms_core/defaults/main.yml` (`pg_version`) |
+| Kafka | `roles/stub_kafka/defaults/main.yml` |
+| Elasticsearch | `roles/stub_elasticsearch/defaults/main.yml` |
+| Grafana | `group_vars/grafana/vars.yml` (`grafana_version`) |
+| Grafana Mimir | `roles/stub_mimir/defaults/main.yml` |
+| Prometheus JMX Exporter | `roles/opennms_core/defaults/main.yml` (`prom_jmx_exporter_version`) |
+| External collections | `requirements.yml` |
+
+The Component Versions table in `CLAUDE.md` should also be in sync.
+
+## Cutting a release
+
+Releases are created from `main` after all intended changes have merged. The repository's branch protection forbids pushing to `main` directly — every change must arrive via a reviewed pull request.
+
+1. **Confirm `main` is at the intended commit.**
+
+   ```bash
+   git checkout main
+   git pull --ff-only
+   gh pr list --state merged --base main -L 10   # sanity-check what's in
+   ```
+
+2. **Review commits since the previous tag.** Conventional Commit prefixes drive the release-note grouping.
+
+   ```bash
+   git log --oneline --no-merges $(git describe --tags --abbrev=0)..HEAD
+   ```
+
+3. **Decide the version bump** (MAJOR / MINOR / PATCH) using the rules above.
+
+4. **Create the GitHub release.** This both creates the tag at `main`'s HEAD and publishes the release notes. Use the template in the next section.
+
+   ```bash
+   gh release create vX.Y.Z \
+     --target main \
+     --title "vX.Y.Z — <headline>" \
+     --notes "$(cat release-notes.md)"
+   ```
+
+   Pass `--draft` first if you want to review on github.com before publishing.
+
+5. **Verify** the tag appears in `git tag --sort=-creatordate | head` and the release page renders correctly.
+
+## Release notes template
+
+Match the structure used by `v0.2.0` and `v0.3.0`. Group changes by Conventional Commit type, omitting empty sections.
+
+```markdown
+## Overview
+
+<One-paragraph headline: the most important user-visible change in this release.>
+
+---
+
+## Changes since vPREV
+
+### Breaking Changes
+- **`role-name`**: <description> (#PR).
+
+### Features
+- **`role-name`**: <description> (#PR).
+
+### Fixes
+- **`role-name`**: <description> (#PR).
+
+### Chores
+- <description>.
+
+---
+
+## Component Versions
+
+| Component | Version |
+|-----------|---------|
+| OpenNMS Horizon | X.Y.Z |
+| PostgreSQL | X |
+| Apache Kafka (KRaft) | X.Y.Z |
+| OpenJDK | X |
+| Grafana | X.Y.Z |
+| Elasticsearch | X.Y.Z |
+| Grafana Mimir | X.Y.Z |
+| Prometheus JMX Exporter | X.Y.Z |
+
+---
+
+## Upgrading from vPREV
+
+<Concrete steps. If a re-run of the playbook is sufficient, say so. If there are manual cleanup steps (e.g., dpkg recovery, config migration), list the exact commands.>
+
+```bash
+ansible-playbook -i inventory/opennms-stack.yml opennms-playbook.yml
+```
+
+**Full changelog:** https://github.com/opennms-forge/ansible-opennms/compare/vPREV...vX.Y.Z
+```
+
+## Ansible Galaxy publishing
+
+The collection is published to Ansible Galaxy as **`indigo423.opennms`**. Publication happens automatically when a GitHub release is published, via `.github/workflows/galaxy-release.yml`.
+
+### One-time prerequisites
+
+1. **Namespace ownership.** The `indigo423` namespace on https://galaxy.ansible.com must be owned (or co-owned) by the account that generates the API token. New collaborators are added via the *Namespaces* page on galaxy.ansible.com.
+2. **API token.** Generate a token at https://galaxy.ansible.com/me/preferences (Preferences → API Key) and store it as the `ANSIBLE_GALAXY_API_KEY` secret under *Settings → Secrets and variables → Actions* for the repo. The token belongs to the user; if it rotates, update the secret.
+
+### Per-release: bump `galaxy.yml`
+
+Before tagging a release, bump the `version:` field in `galaxy.yml` to match the intended tag (without the `v` prefix):
+
+```yaml
+# galaxy.yml
+version: 0.4.0   # matches the upcoming v0.4.0 tag
+```
+
+Include this bump in the same PR that updates role defaults and `CLAUDE.md`'s Component Versions table. The release workflow verifies `galaxy.yml`'s `version` equals `<release-tag>` minus the `v` and fails the build otherwise — this guard catches forgotten bumps before the artifact ships.
+
+### Release flow with Galaxy
+
+1. Open a PR with all role-default bumps, the `CLAUDE.md` Component Versions update, **and** the `galaxy.yml` version bump.
+2. Merge to `main`.
+3. Create the GitHub release at `main` HEAD (see *Cutting a release* above). The `galaxy-release` workflow fires on the `release: published` event, runs the version-match check, builds the collection (`ansible-galaxy collection build`), and publishes the artifact to Galaxy.
+4. Verify the new version appears at https://galaxy.ansible.com/ui/repo/published/indigo423/opennms/ within a couple of minutes.
+
+### Republishing or recovering a failed run
+
+- **CI failed mid-publish (or before the release existed):** edit the GitHub release and click *Publish release* again — this re-fires `release: published` and re-runs the workflow.
+- **Manual fallback** (e.g., to backfill a tag from before this workflow existed):
+
+  ```bash
+  ansible-galaxy collection build --output-path dist/
+  ansible-galaxy collection publish \
+    --token "${ANSIBLE_GALAXY_API_KEY}" \
+    dist/indigo423-opennms-*.tar.gz
+  ```
+
+  Run from a clean checkout of the exact tag you want to ship.
+
+### What gets published
+
+`ansible-galaxy collection build` reads `galaxy.yml` and respects the `build_ignore` list there. The published artifact intentionally excludes:
+
+- `inventory/` — deployment harness, not consumable by collection users.
+- `CLAUDE.md`, `RELEASING.md` — project-internal docs.
+
+The repo's root-level playbooks (`opennms-playbook.yml`, `site.yml`, `hzn-*-deployment.yml`) are currently included as-is. If the collection should expose playbooks via FQCN (e.g., `indigo423.opennms.opennms`), they need to be moved into a `playbooks/` directory in a future PR — this is intentionally out of scope for the initial Galaxy enablement.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,33 @@
+---
+namespace: indigo423
+name: opennms
+version: 0.3.0
+readme: README.md
+authors:
+  - Ronny Trommer <ronny@no42.org>
+description: >-
+  Ansible collection for deploying OpenNMS Horizon monitoring infrastructure
+  (Core, Minion, Sentinel) and supporting services (PostgreSQL, Kafka,
+  Elasticsearch, Grafana, Mimir) on Debian/Ubuntu.
+license:
+  - GPL-3.0-or-later
+tags:
+  - opennms
+  - monitoring
+  - horizon
+  - debian
+  - ubuntu
+  - linux
+dependencies:
+  community.postgresql: '>=4.2.0'
+  community.general: '>=12.6.0'
+  grafana.grafana: '>=6.1.0'
+repository: https://github.com/opennms-forge/ansible-opennms
+homepage: https://github.com/opennms-forge/ansible-opennms
+issues: https://github.com/opennms-forge/ansible-opennms/issues
+# Exclude test-bed scaffolding and project-internal docs from the published artifact.
+# Roles are the consumable surface; playbooks/inventory at the repo root are a deployment harness.
+build_ignore:
+  - inventory
+  - CLAUDE.md
+  - RELEASING.md

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: '>=2.15.0'


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/galaxy-release.yml`, triggered on `release: published`. It verifies `galaxy.yml`'s `version` matches the release tag (without the `v` prefix), runs `ansible-galaxy collection build`, and publishes the resulting tarball to https://galaxy.ansible.com under the `indigo423.opennms` FQCN.
- Adds `galaxy.yml` at the collection root: namespace `indigo423`, name `opennms`, version `0.3.0` (matching the most recent tag), GPL-3.0-or-later license, authorship from the project's git config, and dependency floors derived from `requirements.yml`.
- Adds `meta/runtime.yml` declaring `requires_ansible: '>=2.15.0'`.
- The `build_ignore` list in `galaxy.yml` excludes `inventory/`, `CLAUDE.md`, and `RELEASING.md` so the published artifact ships only the roles + supporting metadata.
- Extends `RELEASING.md` with the Galaxy publishing flow: prerequisites (namespace ownership, `ANSIBLE_GALAXY_API_KEY` repo secret), per-release `galaxy.yml` bump expectation, and the manual `ansible-galaxy collection publish` fallback for backfilling existing tags.

## Required before the first publish merges

Configure the `ANSIBLE_GALAXY_API_KEY` repository secret with an API token generated by an account that owns (or co-owns) the `indigo423` namespace on galaxy.ansible.com:

1. Sign in at https://galaxy.ansible.com with the namespace-owning account.
2. *Preferences → API Key →* generate / copy.
3. *Settings → Secrets and variables → Actions* on this repo → *New repository secret* named `ANSIBLE_GALAXY_API_KEY`.

Without that secret, the workflow's publish step will fail with an auth error.

## Out of scope

- Restructuring root-level playbooks (`opennms-playbook.yml`, `site.yml`, `hzn-*-deployment.yml`) into a `playbooks/` directory so they're invocable via FQCN. Tracked as a follow-up.
- Backfilling `v0.3.0` onto Galaxy. After this PR merges, that can be done manually with the steps documented in `RELEASING.md` (or by editing the v0.3.0 GitHub release to re-fire the `release: published` event — note that `galaxy.yml` is currently pinned to `0.3.0`).

## Test plan

- [ ] Confirm `ansible-lint` passes against the new files (existing lint workflow runs on push).
- [ ] After merge, configure the `ANSIBLE_GALAXY_API_KEY` secret.
- [ ] Cut a `v0.3.1` patch release (or trigger v0.3.0 backfill via release re-publish) and confirm `indigo423.opennms` appears on galaxy.ansible.com.
- [ ] Verify the version-match guard by temporarily desyncing `galaxy.yml` vs. tag on a throwaway draft release — expect the workflow to fail with the explicit error message.