### PR TITLE
fix(roles): add per-role meta/main.yml and README for Galaxy import

### DIFF
--- a/roles/common/README.md
+++ b/roles/common/README.md
@@ -1,0 +1,21 @@
+# common
+
+Base system configuration (timezone, APT cache, common packages) for hosts running OpenNMS components.
+
+Part of the [`indigo423.opennms`](https://galaxy.ansible.com/ui/repo/published/indigo423/opennms/) collection.
+
+## Variables
+
+See [`defaults/main.yml`](defaults/main.yml).
+
+## Example
+
+```yaml
+- hosts: all
+  roles:
+    - indigo423.opennms.common
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: common
+  author: Ronny Trommer
+  description: Base system configuration (timezone, APT cache, common packages) for hosts running OpenNMS components.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - system
+    - base
+    - monitoring
+
+dependencies: []

--- a/roles/grafana_provisioning/README.md
+++ b/roles/grafana_provisioning/README.md
@@ -1,0 +1,21 @@
+# grafana_provisioning
+
+Drops the OpenNMS Grafana app plugin provisioning file so the plugin installed by the `grafana.grafana` collection is enabled.
+
+Part of the [`indigo423.opennms`](https://galaxy.ansible.com/ui/repo/published/indigo423/opennms/) collection.
+
+## Variables
+
+See [`defaults/main.yml`](defaults/main.yml).
+
+## Example
+
+```yaml
+- hosts: all
+  roles:
+    - indigo423.opennms.grafana_provisioning
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/grafana_provisioning/meta/main.yml
+++ b/roles/grafana_provisioning/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: grafana_provisioning
+  author: Ronny Trommer
+  description: Drops the OpenNMS Grafana app plugin provisioning file so the plugin installed by the grafana.grafana collection is enabled.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - grafana
+    - monitoring
+    - opennms
+
+dependencies: []

--- a/roles/openjdk/README.md
+++ b/roles/openjdk/README.md
@@ -1,0 +1,24 @@
+# openjdk
+
+Installs and configures the OpenJDK runtime used by OpenNMS Horizon components.
+
+Part of the [`indigo423.opennms`](https://galaxy.ansible.com/ui/repo/published/indigo423/opennms/) collection.
+
+## Variables
+
+See [`defaults/main.yml`](defaults/main.yml).
+
+## Example
+
+```yaml
+- hosts: all
+  roles:
+    - role: indigo423.opennms.openjdk
+      vars:
+        openjdk_version: 21
+        openjdk_pkg_version: "21*"
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/openjdk/meta/main.yml
+++ b/roles/openjdk/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: openjdk
+  author: Ronny Trommer
+  description: Installs and configures the OpenJDK runtime used by OpenNMS Horizon components.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - java
+    - jdk
+    - runtime
+
+dependencies: []

--- a/roles/opennms_core/README.md
+++ b/roles/opennms_core/README.md
@@ -1,0 +1,21 @@
+# opennms_core
+
+Deploys and configures OpenNMS Horizon Core: server packages, webapp, database initialization, Kafka IPC, JVM tuning, JMX Prometheus exporter, and UFW firewall rules.
+
+Part of the [`indigo423.opennms`](https://galaxy.ansible.com/ui/repo/published/indigo423/opennms/) collection.
+
+## Variables
+
+See [`defaults/main.yml`](defaults/main.yml).
+
+## Example
+
+```yaml
+- hosts: opennms_core
+  roles:
+    - indigo423.opennms.opennms_core
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/opennms_core/meta/main.yml
+++ b/roles/opennms_core/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: opennms_core
+  author: Ronny Trommer
+  description: Deploys and configures OpenNMS Horizon Core (server, webapp, database init, Kafka IPC, UFW rules) on Debian/Ubuntu.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - opennms
+    - monitoring
+    - networking
+
+dependencies: []

--- a/roles/opennms_icmp/README.md
+++ b/roles/opennms_icmp/README.md
@@ -1,0 +1,21 @@
+# opennms_icmp
+
+Installs `jicmp` / `jicmp6` native libraries used by OpenNMS Horizon components for ICMP monitoring.
+
+Part of the [`indigo423.opennms`](https://galaxy.ansible.com/ui/repo/published/indigo423/opennms/) collection.
+
+## Variables
+
+See [`defaults/main.yml`](defaults/main.yml).
+
+## Example
+
+```yaml
+- hosts: all
+  roles:
+    - indigo423.opennms.opennms_icmp
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/opennms_icmp/meta/main.yml
+++ b/roles/opennms_icmp/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: opennms_icmp
+  author: Ronny Trommer
+  description: Installs jicmp/jicmp6 native libraries used by OpenNMS Horizon components for ICMP monitoring.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - opennms
+    - icmp
+    - monitoring
+
+dependencies: []

--- a/roles/opennms_minion/README.md
+++ b/roles/opennms_minion/README.md
@@ -1,0 +1,21 @@
+# opennms_minion
+
+Deploys and configures the OpenNMS Minion agent for monitoring isolated network segments.
+
+Part of the [`indigo423.opennms`](https://galaxy.ansible.com/ui/repo/published/indigo423/opennms/) collection.
+
+## Variables
+
+See [`defaults/main.yml`](defaults/main.yml).
+
+## Example
+
+```yaml
+- hosts: opennms_minion
+  roles:
+    - indigo423.opennms.opennms_minion
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/opennms_minion/meta/main.yml
+++ b/roles/opennms_minion/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: opennms_minion
+  author: Ronny Trommer
+  description: Deploys and configures the OpenNMS Minion agent for monitoring isolated network segments.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - opennms
+    - monitoring
+    - agent
+
+dependencies: []

--- a/roles/opennms_repositories/README.md
+++ b/roles/opennms_repositories/README.md
@@ -1,0 +1,23 @@
+# opennms_repositories
+
+Adds the OpenNMS APT repository (`debian.opennms.org`) and the upstream GPG signing key on Debian/Ubuntu hosts.
+
+Must run before any OpenNMS package install.
+
+Part of the [`indigo423.opennms`](https://galaxy.ansible.com/ui/repo/published/indigo423/opennms/) collection.
+
+## Variables
+
+See [`defaults/main.yml`](defaults/main.yml).
+
+## Example
+
+```yaml
+- hosts: all
+  roles:
+    - indigo423.opennms.opennms_repositories
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/opennms_repositories/meta/main.yml
+++ b/roles/opennms_repositories/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: opennms_repositories
+  author: Ronny Trommer
+  description: Adds the OpenNMS APT repository and GPG signing key on Debian/Ubuntu hosts. Must run before any OpenNMS package install.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - opennms
+    - apt
+    - repository
+
+dependencies: []

--- a/roles/opennms_sentinel/README.md
+++ b/roles/opennms_sentinel/README.md
@@ -1,0 +1,21 @@
+# opennms_sentinel
+
+Deploys and configures OpenNMS Sentinel for distributed workload scaling and flow aggregation.
+
+Part of the [`indigo423.opennms`](https://galaxy.ansible.com/ui/repo/published/indigo423/opennms/) collection.
+
+## Variables
+
+See [`defaults/main.yml`](defaults/main.yml).
+
+## Example
+
+```yaml
+- hosts: opennms_sentinel
+  roles:
+    - indigo423.opennms.opennms_sentinel
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/opennms_sentinel/meta/main.yml
+++ b/roles/opennms_sentinel/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: opennms_sentinel
+  author: Ronny Trommer
+  description: Deploys and configures OpenNMS Sentinel for distributed workload scaling and flow aggregation.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - opennms
+    - monitoring
+    - flows
+
+dependencies: []

--- a/roles/stub_elasticsearch/README.md
+++ b/roles/stub_elasticsearch/README.md
@@ -1,0 +1,23 @@
+# stub_elasticsearch
+
+POC / test stub that deploys a single-node Elasticsearch instance for OpenNMS flow data.
+
+> **Not for production.** This role exists for evaluation and CI scenarios only. Use a dedicated Elasticsearch operator or cluster role for real deployments.
+
+Part of the [`indigo423.opennms`](https://galaxy.ansible.com/ui/repo/published/indigo423/opennms/) collection.
+
+## Variables
+
+See [`defaults/main.yml`](defaults/main.yml).
+
+## Example
+
+```yaml
+- hosts: elasticsearch
+  roles:
+    - indigo423.opennms.stub_elasticsearch
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/stub_elasticsearch/meta/main.yml
+++ b/roles/stub_elasticsearch/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: stub_elasticsearch
+  author: Ronny Trommer
+  description: POC/test stub that deploys a single-node Elasticsearch instance for OpenNMS flow data. Not for production use.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - elasticsearch
+    - search
+    - stub
+
+dependencies: []

--- a/roles/stub_kafka/README.md
+++ b/roles/stub_kafka/README.md
@@ -1,0 +1,23 @@
+# stub_kafka
+
+POC / test stub that deploys Apache Kafka 4.x in KRaft mode for OpenNMS IPC.
+
+> **Not for production.** Use a dedicated Kafka operator or cluster role for real deployments.
+
+Part of the [`indigo423.opennms`](https://galaxy.ansible.com/ui/repo/published/indigo423/opennms/) collection.
+
+## Variables
+
+See [`defaults/main.yml`](defaults/main.yml).
+
+## Example
+
+```yaml
+- hosts: kafka
+  roles:
+    - indigo423.opennms.stub_kafka
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/stub_kafka/meta/main.yml
+++ b/roles/stub_kafka/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: stub_kafka
+  author: Ronny Trommer
+  description: POC/test stub that deploys Apache Kafka 4.x in KRaft mode for OpenNMS IPC. Not for production use.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - kafka
+    - messaging
+    - stub
+
+dependencies: []

--- a/roles/stub_mimir/README.md
+++ b/roles/stub_mimir/README.md
@@ -1,0 +1,23 @@
+# stub_mimir
+
+POC / test stub that deploys Grafana Mimir for OpenNMS time-series storage.
+
+> **Not for production.** Use a dedicated Mimir cluster role or the Grafana Cloud offering for real deployments.
+
+Part of the [`indigo423.opennms`](https://galaxy.ansible.com/ui/repo/published/indigo423/opennms/) collection.
+
+## Variables
+
+See [`defaults/main.yml`](defaults/main.yml).
+
+## Example
+
+```yaml
+- hosts: mimir
+  roles:
+    - indigo423.opennms.stub_mimir
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/stub_mimir/meta/main.yml
+++ b/roles/stub_mimir/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: stub_mimir
+  author: Ronny Trommer
+  description: POC/test stub that deploys Grafana Mimir for OpenNMS time-series storage. Not for production use.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - mimir
+    - metrics
+    - stub
+
+dependencies: []

--- a/roles/stub_pgsql/README.md
+++ b/roles/stub_pgsql/README.md
@@ -1,0 +1,23 @@
+# stub_pgsql
+
+POC / test stub that deploys PostgreSQL with the OpenNMS database and user provisioned.
+
+> **Not for production.** Use a dedicated PostgreSQL operator, managed service, or a cluster role with backup/HA for real deployments.
+
+Part of the [`indigo423.opennms`](https://galaxy.ansible.com/ui/repo/published/indigo423/opennms/) collection.
+
+## Variables
+
+See [`defaults/main.yml`](defaults/main.yml).
+
+## Example
+
+```yaml
+- hosts: postgresql
+  roles:
+    - indigo423.opennms.stub_pgsql
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/stub_pgsql/meta/main.yml
+++ b/roles/stub_pgsql/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: stub_pgsql
+  author: Ronny Trommer
+  description: POC/test stub that deploys PostgreSQL with the OpenNMS database and user provisioned. Not for production use.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - postgresql
+    - database
+    - stub
+
+dependencies: []


### PR DESCRIPTION
## Summary

The v0.3.1 Galaxy publish ([run 26420459472](https://github.com/opennms-forge/ansible-opennms/actions/runs/26420459472/job/77773971231)) uploaded the tarball but was **rejected during Galaxy's import validation**:

```
[WARNING]: Could not get role description, no role metadata found
[ERROR]: Galaxy import process failed: No role readme found.
```

Galaxy's importer walks every role embedded in a collection and requires:

- `meta/main.yml` with at least `galaxy_info.description`
- a `README.md` at the role root

Neither existed for any of the 12 roles, so the artifact never made it into the published index (`https://galaxy.ansible.com/api/v3/.../indigo423/opennms/` returned 404).

This PR scaffolds both files for all 12 roles (`common`, `grafana_provisioning`, `openjdk`, `opennms_core`, `opennms_icmp`, `opennms_minion`, `opennms_repositories`, `opennms_sentinel`, `stub_elasticsearch`, `stub_kafka`, `stub_mimir`, `stub_pgsql`) with consistent metadata:

- author: Ronny Trommer
- license: GPL-3.0-or-later (matches the collection)
- min_ansible_version: 2.15
- platforms: Debian (bookworm, trixie) + Ubuntu (jammy, noble)
- per-role `galaxy_tags` (opennms/monitoring, plus role-specific terms)

Each README is short and points readers at the role's `defaults/main.yml` for variables.

## What about v0.3.1?

v0.3.1 stays in the GitHub release history as an accurate record of the failed publish — Galaxy doesn't allow re-uploading the same version number. The next release (v0.3.2) will be the first one to actually appear under `indigo423.opennms` on galaxy.ansible.com.

## Test plan

- [ ] `ansible-lint` passes against the production profile with the new metadata.
- [ ] After merge, cut v0.3.2 (separate PR bumping `galaxy.yml` + `CHANGELOG.md`).
- [ ] Confirm `https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/indigo423/opennms/versions/0.3.2/` returns 200.