### PR TITLE
fix(opennms_core): use scvcli get instead of show

### DIFF
--- a/roles/opennms_core/tasks/10-database-setup.yml
+++ b/roles/opennms_core/tasks/10-database-setup.yml
@@ -127,7 +127,7 @@
 - name: Verify SCV has the expected credentials before OpenNMS reads them
   become: true
   become_user: opennms
-  ansible.builtin.command: "{{ opennms_home }}/bin/scvcli show {{ item }}"
+  ansible.builtin.command: "{{ opennms_home }}/bin/scvcli get {{ item }}"
   loop:
     - postgres
     - postgres-admin


### PR DESCRIPTION
## Summary

- `scvcli` has no `show` subcommand — supported verbs are `set`, `get`, `get-all`, `list`, `delete`. The verify step in `roles/opennms_core/tasks/10-database-setup.yml` fails on any OpenNMS Horizon release shipping the current `scvcli` usage with: `Error: "show" is not a valid value for "ACTION"`.
- `get ALIAS` has the same signature and returns the stored entry, satisfying the existing `failed_when: scv_verify.rc != 0 or stdout is empty` check.
- One-line change to line 130; no other behavior altered.

## Test plan

- [ ] Run the `opennms_core` role against an OpenNMS Horizon target after `init_secrets` populated the vault — the `Verify SCV has the expected credentials before OpenNMS reads them` task should succeed for both `postgres` and `postgres-admin` aliases.
- [ ] Confirm `failed_when` still trips when an alias is missing (sanity check that the verify guard still has teeth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)