### PR TITLE
chore(release): v0.4.1 + clarify RELEASING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the `indigo423.opennms` collection are documented in this
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each entry below is a short index; the corresponding GitHub release contains the full notes including the Component Versions table and upgrade instructions.
 
+## [0.4.1] - 2026-05-28
+
+### Fixed
+- `opennms_core`: replace `scvcli show` with `scvcli get` in the post-credential verification step. `scvcli` has no `show` subcommand; the supported verbs are `set`, `get`, `get-all`, `list`, `delete`. Every deployment failed immediately after `init_secrets` populated the SCV vault with `Error: "show" is not a valid value for "ACTION"`. `get ALIAS` has the same signature and returns the stored entry, satisfying the existing `failed_when` guard (#93).
+
 ## [0.4.0] - 2026-05-28
 
 ### Added

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,11 +34,12 @@ The Component Versions table in `CLAUDE.md` should also be in sync.
 
 Releases are created from `main` after all intended changes have merged. The repository's branch protection forbids pushing to `main` directly — every change must arrive via a reviewed pull request.
 
-1. **Confirm `main` is at the intended commit.**
+1. **Land the release-prep PR.** Before tagging, `main` must already contain the `galaxy.yml` version bump and a matching `CHANGELOG.md` entry — see [Per-release: bump `galaxy.yml` and update `CHANGELOG.md`](#per-release-bump-galaxyyml-and-update-changelogmd). The `galaxy-release.yml` workflow refuses to publish if `galaxy.yml`'s `version:` field at the tagged commit doesn't match the tag (minus the `v` prefix). Confirm `main` is at the intended commit:
 
    ```bash
    git checkout main
    git pull --ff-only
+   grep '^version:' galaxy.yml          # must read X.Y.Z (no leading v)
    gh pr list --state merged --base main -L 10   # sanity-check what's in
    ```
 
@@ -150,6 +151,15 @@ Before tagging a release, two files must be updated in the same PR that bumps ro
 ### Republishing or recovering a failed run
 
 - **CI failed mid-publish (or before the release existed):** edit the GitHub release and click *Publish release* again — this re-fires `release: published` and re-runs the workflow.
+- **`galaxy.yml` version doesn't match the tag** (the bump was forgotten): the safe path is **forward-only** — cut the next patch version. Bump `galaxy.yml` and `CHANGELOG.md` on a new PR, merge, then tag and release `vX.Y.(Z+1)`. The failed `vX.Y.Z` release stays in place (delete it on GitHub if you want, but don't rewrite the tag — it's published state). Rewriting a tag is only acceptable when it's minutes old and you can confirm no consumer fetched it; in that narrow case:
+
+  ```bash
+  gh release delete vX.Y.Z --yes
+  git push origin :refs/tags/vX.Y.Z
+  git tag -d vX.Y.Z
+  # fix galaxy.yml + CHANGELOG.md on a PR, merge, then re-tag and re-release.
+  ```
+
 - **Manual fallback** (e.g., to backfill a tag from before this workflow existed):
 
   ```bash

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: indigo423
 name: opennms
-version: 0.4.0
+version: 0.4.1
 readme: README.md
 authors:
   - Ronny Trommer <ronny@no42.org>


### PR DESCRIPTION
## Summary

- Bumps `galaxy.yml` to `0.4.1` and adds a `[0.4.1]` entry to `CHANGELOG.md` so the `galaxy-release.yml` workflow's version-match check passes when the tag is cut.
- Tightens `RELEASING.md`: the "Cutting a release" section now explicitly checks `galaxy.yml`'s version on `main` before tagging (preventing the failure mode that burned the first `v0.4.1` attempt — [run #26544824633](https://github.com/opennms-forge/ansible-opennms/actions/runs/26544824633)) and the recovery section gained a "galaxy.yml didn't match the tag" path that prefers forward-only patch bumps over tag rewrites.

## Test plan

- [ ] After merge, tag `v0.4.1` from `main`'s HEAD and publish the GitHub release — `galaxy-release.yml` should pass the version-match step and publish `indigo423.opennms` v0.4.1 to Galaxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)