### PR TITLE
fix(grafana_provisioning): install opennms-opennms-app via grafana-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the `indigo423.opennms` collection are documented in this
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each entry below is a short index; the corresponding GitHub release contains the full notes including the Component Versions table and upgrade instructions.
 
+## [0.4.2] - 2026-05-28
+
+### Fixed
+- `grafana_provisioning`: install `opennms-opennms-app` via `grafana-cli` before dropping the provisioning file that enables it. Previously the role copied a provisioning entry referencing the plugin but never installed it, so `grafana-server` failed to start with `Failed to provision plugins: plugin not installed: "opennms-opennms-app"` whenever the role ran against a fresh host. README and `meta/main.yml` updated to reflect the role's expanded scope.
+
 ## [0.4.1] - 2026-05-28
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: indigo423
 name: opennms
-version: 0.4.1
+version: 0.4.2
 readme: README.md
 authors:
   - Ronny Trommer <ronny@no42.org>

--- a/roles/grafana_provisioning/README.md
+++ b/roles/grafana_provisioning/README.md
@@ -1,6 +1,8 @@
 # grafana_provisioning
 
-Drops the OpenNMS Grafana app plugin provisioning file so the plugin installed by the `grafana.grafana` collection is enabled.
+Installs the OpenNMS Grafana app plugin (`opennms-opennms-app`) via `grafana-cli` and drops the provisioning file that enables it. Both steps notify a `restart_grafana` handler so a co-located `grafana.grafana.grafana` role picks up the new plugin on its next service restart.
+
+Run this role **after** `grafana.grafana.grafana` (or any equivalent Grafana install role) on the same host — `grafana-cli` and the `/var/lib/grafana/plugins` directory must already exist.
 
 Part of the [`indigo423.opennms`](https://galaxy.ansible.com/ui/repo/published/indigo423/opennms/) collection.
 

--- a/roles/grafana_provisioning/meta/main.yml
+++ b/roles/grafana_provisioning/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   role_name: grafana_provisioning
   author: Ronny Trommer
-  description: Drops the OpenNMS Grafana app plugin provisioning file so the plugin installed by the grafana.grafana collection is enabled.
+  description: Installs the OpenNMS Grafana app plugin (via grafana-cli) and drops the provisioning file that enables it.
   license: GPL-3.0-or-later
   min_ansible_version: "2.15"
   platforms:

--- a/roles/grafana_provisioning/tasks/main.yml
+++ b/roles/grafana_provisioning/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Install the opennms-opennms-app plugin
+  ansible.builtin.command:
+    cmd: grafana-cli plugins install opennms-opennms-app
+    creates: /var/lib/grafana/plugins/opennms-opennms-app
+  notify: restart_grafana
+  tags:
+    - grafana
+    - plugin
+
 - name: Enable opennms-opennms-app plugin
   ansible.builtin.copy:
     src: plugins/opennms-app.yml

--- a/roles/grafana_provisioning/tasks/main.yml
+++ b/roles/grafana_provisioning/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Install the opennms-opennms-app plugin
   ansible.builtin.command:
     cmd: grafana-cli plugins install opennms-opennms-app
+    chdir: /usr/share/grafana
     creates: /var/lib/grafana/plugins/opennms-opennms-app
   notify: restart_grafana
   tags:


### PR DESCRIPTION
## Summary

- The `grafana_provisioning` role dropped `/etc/grafana/provisioning/plugins/opennms-app.yml` referencing `opennms-opennms-app`, but never installed the plugin. On any fresh host `grafana-server` then refused to start with `Failed to provision plugins: plugin not installed: "opennms-opennms-app"`, timing out downstream `Wait for grafana to start` steps in `grafana.grafana.grafana`.
- Adds a `grafana-cli plugins install opennms-opennms-app` task before the file copy, guarded by `creates: /var/lib/grafana/plugins/opennms-opennms-app` for idempotency. Both tasks `notify: restart_grafana` so the existing handler from `grafana.grafana.grafana` picks up the change at end of play.
- Bumps `galaxy.yml` to `0.4.2` and adds a matching `CHANGELOG.md` entry, per `RELEASING.md`.
- README and `meta/main.yml` updated to reflect the role's expanded scope (installs + enables, not just enables) and the documented prerequisite that `grafana.grafana.grafana` runs first on the same host.

## Test plan

- [ ] Run the `Manage Grafana` play against a fresh host where grafana-server was never started — `grafana-server.service` should reach `Active: active (running)` and the `Wait for grafana to start` step should pass.
- [ ] Re-run on the same host — the install task should be skipped (`creates:` short-circuit) and the provisioning file copy should be a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)