### PR TITLE
fix(opennms_icmp): default jicmp/jicmp6 versions to repo candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the `indigo423.opennms` collection are documented in this
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each entry below is a short index; the corresponding GitHub release contains the full notes including the Component Versions table and upgrade instructions.
 
+## [0.4.3] - 2026-05-29
+
+### Fixed
+- `opennms_icmp`: stop defaulting `jicmp_version`/`jicmp6_version` to the stale `3.*` major. On a host that already carries the newer libraries a later Horizon release pulls in (e.g. `4.0.0-1` under Horizon 36), `apt` treated `3.*` as a downgrade and aborted with `E: Packages were downgraded and -y was used without --allow-downgrades`. The defaults now use `*`, which resolves to the configured repo's candidate and stays idempotent. Consumers needing a frozen build can still override these.
+
 ## [0.4.2] - 2026-05-28
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: indigo423
 name: opennms
-version: 0.4.2
+version: 0.4.3
 readme: README.md
 authors:
   - Ronny Trommer <ronny@no42.org>

--- a/roles/opennms_icmp/defaults/main.yml
+++ b/roles/opennms_icmp/defaults/main.yml
@@ -1,3 +1,8 @@
 ---
-jicmp_version: 3.*
-jicmp6_version: 3.*
+# Track whatever jicmp/jicmp6 the configured OpenNMS repo offers rather than
+# pinning a major. A frozen major (e.g. 3.*) becomes a downgrade — and apt
+# refuses it without --allow-downgrades — once a host carries the newer libs a
+# later Horizon release pulls in. "*" resolves to the repo candidate and stays
+# idempotent. Consumers that need a frozen build can still override these.
+jicmp_version: "*"
+jicmp6_version: "*"


### PR DESCRIPTION
## What

Change the `opennms_icmp` role defaults for `jicmp_version` / `jicmp6_version` from the frozen `3.*` major to `*` (the configured repo's candidate).

## Why

On a host that already carries the newer ICMP libraries a later Horizon release pulls in (e.g. `jicmp 4.0.0-1` under Horizon 36), `apt` treats the pinned `3.*` as a downgrade and aborts the play:

```
E: Packages were downgraded and -y was used without --allow-downgrades
```

`3.*` is a stale literal that has to be hand-bumped every time Horizon moves the ICMP major. `*` resolves to the repo candidate, stays idempotent (`apt-get install jicmp=*` → "already the newest version"), and never goes stale. Consumers needing a frozen build can still override the variables.

## Changes

- `roles/opennms_icmp/defaults/main.yml`: `3.*` → `*` for both vars, with rationale comment
- `galaxy.yml`: `0.4.2` → `0.4.3` (PATCH — default-value fix, variable contract unchanged)
- `CHANGELOG.md`: `[0.4.3]` entry

## Test

- `apt-get -s install 'jicmp=*'` on a Horizon 36 host already at `jicmp 4.0.0-1` resolves to the candidate and reports no change (idempotent, no downgrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)