### PR TITLE
fix(opennms_core): export env vars in opennms.conf so the JVM sees them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the `indigo423.opennms` collection are documented in this
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each entry below is a short index; the corresponding GitHub release contains the full notes including the Component Versions table and upgrade instructions.
 
+## [0.4.4] - 2026-05-29
+
+### Fixed
+- `opennms_core`: export the env-var and service entries in `opennms.conf` so they reach the JVM. `bin/install` (`. opennms.conf`) and `bin/opennms` (`__onms_read_conf`) both source the file without auto-export, so the unexported `POSTGRES_HOST`/`POSTGRES_PORT`/`OPENNMS_DBNAME` (and `CORE_SERVICE_*_ENABLED`) entries stayed shell-local and never reached the JVM. The `${env:...}` placeholders in the pristine `opennms-datasources.xml` then fell back to their literals — every deployment with a non-`localhost` database failed at `install -dis` and at runtime with `Connection to localhost:5432 refused`. JVM tunables (`JAVA_HEAP_SIZE`, `ADDITIONAL_MANAGER_OPTIONS`) remain unexported as they are read as shell variables.
+
 ## [0.4.3] - 2026-05-29
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: indigo423
 name: opennms
-version: 0.4.3
+version: 0.4.4
 readme: README.md
 authors:
   - Ronny Trommer <ronny@no42.org>

--- a/roles/opennms_core/templates/etc/opennms.conf.j2
+++ b/roles/opennms_core/templates/etc/opennms.conf.j2
@@ -8,12 +8,19 @@
 {%- set _svc_keys = opennms_services.keys() | list %}
 {%- set _collisions = (_jvm_keys | intersect(_env_keys)) + (_jvm_keys | intersect(_svc_keys)) + (_env_keys | intersect(_svc_keys)) %}
 {%- if _collisions | length > 0 %}{{ undef('opennms.conf: duplicate keys across opennms_jvm_conf / opennms_env / opennms_services: ' ~ (_collisions | unique | join(', '))) }}{% endif %}
+{# JVM tunables are consumed as shell variables by bin/opennms and bin/install,
+   so they are not exported. The env-var and service entries below are exported
+   because the pristine opennms-datasources.xml (and the CORE_SERVICE_*_ENABLED
+   toggles) resolve them via ${env:VAR}, i.e. the JVM's process environment.
+   bin/install (. opennms.conf) and bin/opennms (__onms_read_conf) both source
+   this file without auto-export, so without `export` the values stay shell-local
+   and the JVM falls back to the literal defaults (e.g. localhost:5432). #}
 {% for (key, value) in opennms_jvm_conf.items() -%}
 {{ key }}="{{ value | string | replace('\\', '\\\\') | replace('"', '\\"') }}"
 {% endfor -%}
 {% for (key, value) in _env_merged.items() -%}
-{{ key }}="{{ value | string | replace('\\', '\\\\') | replace('"', '\\"') }}"
+export {{ key }}="{{ value | string | replace('\\', '\\\\') | replace('"', '\\"') }}"
 {% endfor -%}
 {% for (key, value) in opennms_services.items() -%}
-{{ key }}="{{ value | string | lower | replace('\\', '\\\\') | replace('"', '\\"') }}"
+export {{ key }}="{{ value | string | lower | replace('\\', '\\\\') | replace('"', '\\"') }}"
 {% endfor -%}


### PR DESCRIPTION
## What

Prefix the env-var entries (and `CORE_SERVICE_*_ENABLED` service toggles) in `opennms.conf.j2` with `export`. JVM tunables (`JAVA_HEAP_SIZE`, `ADDITIONAL_MANAGER_OPTIONS`) stay unexported.

## Why

`bin/install` (`. opennms.conf`) and `bin/opennms` (`__onms_read_conf`) both **source** `opennms.conf` without auto-exporting. The datasource env vars were emitted as plain `KEY="value"`, so they stayed shell-local and never reached the `java` child. The `${env:...}` placeholders in the pristine `opennms-datasources.xml` then fell back to their literals:

```
jdbc:postgresql://localhost:5432/opennms   ← POSTGRES_HOST/OPENNMS_DBNAME never set
PSQLException: Connection to localhost:5432 refused
```

Every deployment with a non-`localhost` database failed — both at `install -dis` and at runtime (`DatabaseChecker` in `manager.log`). Verified against a Horizon 36 lab: with the vars exported, `install -dis` connects to the real DB host and completes.

## Changes

- `roles/opennms_core/templates/etc/opennms.conf.j2`: `export` on the `_env_merged` and `opennms_services` loops, with an explanatory comment
- `galaxy.yml`: `0.4.3` → `0.4.4` (PATCH — bug fix, no contract change)
- `CHANGELOG.md`: `[0.4.4]` entry

## Safety

- The systemd unit does **not** use `opennms.conf` as an `EnvironmentFile` (it runs `bin/opennms -s start`), so `export` lines won't break unit parsing.
- `__onms_read_conf`'s `OVERRIDEABLE_ARRAYS` sed only rewrites array-var names; these scalar keys are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)