### PR TITLE
fix(opennms_minion): pin JAVA_HOME so the service can find the JDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the `indigo423.opennms` collection are documented in this
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each entry below is a short index; the corresponding GitHub release contains the full notes including the Component Versions table and upgrade instructions.
 
+## [0.4.6] - 2026-05-29
+
+### Fixed
+- `opennms_minion`: pin `JAVA_HOME` in `/etc/default/minion`. Unlike `opennms_core` (which runs `runjava -s`), the Minion role never told the service where Java is, so it fell back to karaf's `bin/find-java.sh`, whose max-version cap rejects current JDKs (e.g. 21) and aborted startup with `JAVA_HOME is not valid: No match found!` — `minion.service` failed to start. The role now resolves the installed JDK (`readlink -f /usr/bin/java`) and writes `JAVA_HOME` into the unit's EnvironmentFile, bypassing the broken auto-detection.
+
 ## [0.4.5] - 2026-05-29
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: indigo423
 name: opennms
-version: 0.4.5
+version: 0.4.6
 readme: README.md
 authors:
   - Ronny Trommer <ronny@no42.org>

--- a/roles/opennms_minion/tasks/main.yml
+++ b/roles/opennms_minion/tasks/main.yml
@@ -24,6 +24,34 @@
     - minion
     - package
 
+- name: Resolve the installed JDK home
+  ansible.builtin.command: readlink -f /usr/bin/java
+  register: opennms_minion_java_bin
+  changed_when: false
+  tags:
+    - opennms
+    - minion
+
+# The Minion service has no equivalent of Core's `runjava -s`; with JAVA_HOME
+# unset it falls back to karaf's bin/find-java.sh, whose max-version cap rejects
+# current JDKs (e.g. 21) and aborts startup with "JAVA_HOME is not valid: No
+# match found!". Pin JAVA_HOME in the unit's EnvironmentFile (no `export` — it is
+# parsed by systemd as KEY=value) so detection is bypassed.
+- name: Point the Minion service at the installed JDK
+  ansible.builtin.lineinfile:
+    path: /etc/default/minion
+    regexp: '^#?\s*(export\s+)?JAVA_HOME='
+    line: "JAVA_HOME={{ opennms_minion_java_bin.stdout | dirname | dirname }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Restart minion
+  tags:
+    - opennms
+    - minion
+    - configuration
+
 - name: Configure Minion system properties
   ansible.builtin.template:
     src: custom.system.properties.j2


### PR DESCRIPTION
## What

Resolve the installed JDK and write `JAVA_HOME` into `/etc/default/minion` (the `minion.service` `EnvironmentFile`).

## Why

Unlike `opennms_core` (which runs `runjava -s`), the Minion role never told the service where Java is. With `JAVA_HOME` unset, the start script falls back to karaf's `bin/find-java.sh`, whose `max_java_version` cap rejects current JDKs (e.g. 21):

```
karaf: JAVA_HOME is not valid: No match found!
```

`minion.service` then fails to start (`status=1/FAILURE`, no logs written — the JVM never launches). This breaks any host running a JDK newer than the script's cap, including OpenNMS 36's own JDK 21.

## Fix

```yaml
- command: readlink -f /usr/bin/java        # → /usr/lib/jvm/java-21-openjdk-amd64/bin/java
- lineinfile: JAVA_HOME={{ ... | dirname | dirname }}  # /etc/default/minion
```

Derived from the live binary (arch-independent), written without `export` so systemd parses it as `KEY=value`. A set `JAVA_HOME` bypasses `find-java.sh` entirely.

## Verification

On a Horizon 36 lab (Ubuntu 24.04, OpenJDK 21): after the change `minion.service` is `active`, karaf runs on `/usr/lib/jvm/java-21-openjdk-amd64/bin/java`, and `/etc/default/minion` contains `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64`.

## Changes

- `roles/opennms_minion/tasks/main.yml`: resolve JDK + set `JAVA_HOME` (notifies `Restart minion`)
- `galaxy.yml`: `0.4.5` → `0.4.6`
- `CHANGELOG.md`: `[0.4.6]` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)