### PR TITLE
ci: add dependabot config to keep action SHA pins current

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Why

Both workflows (`ansible-opennms-lint.yml`, `galaxy-release.yml`) pin actions to immutable SHAs with full-semver trailing comments, but nothing keeps those pins current — they go stale silently, missing upstream security and bug fixes.

## What

Adds `.github/dependabot.yml` watching the `github-actions` ecosystem:

- **Weekly schedule (Monday)** — action releases are infrequent; keeps noise low
- **`open-pull-requests-limit: 5`** — explicit bound (only two distinct actions are in use, so rarely reached)
- **`commit-message.prefix: "ci"`** — Dependabot PRs land as Conventional Commits (`ci: bump actions/checkout ...`)

Dependabot natively understands the SHA-pin-plus-comment style: its PRs bump the SHA and rewrite the trailing `# vX.Y.Z` comment.

## Out of scope

- `pip` ecosystem: CI installs `ansible-core`/`ansible-lint` via inline `pip install` in workflow run steps — no `requirements.txt` manifest exists for Dependabot to watch
- Ansible collections in `requirements.yml`: no Dependabot ecosystem supports them

## Verification

- `python3 -c 'import yaml; yaml.safe_load(open(".github/dependabot.yml"))'` parses cleanly
- After merge: Insights → Dependency graph → Dependabot should show version updates enabled for `github-actions` with no config errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)