### PR TITLE
chore(deps): let Renovate manage opennms and jmx_exporter versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,27 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "schedule": ["before 6am on monday"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update version variables annotated with a '# renovate:' comment in role defaults",
+      "managerFilePatterns": ["/^roles/[^/]+/defaults/main\\.yml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+?)(?: extractVersion=(?<extractVersion>\\S+))?\\s*\\n[a-z0-9_]+: (?<currentValue>\\S+)"
+      ]
+    }
+  ],
   "packageRules": [
+    {
+      "matchManagers": ["custom.regex"],
+      "labels": ["dependencies"]
+    },
+    {
+      "matchDepNames": ["prometheus/jmx_exporter"],
+      "prBodyNotes": [
+        "**Before merging:** update `prom_jmx_exporter_sha256` in `roles/opennms_core/defaults/main.yml` to the new jar's checksum (the release publishes a `jmx_prometheus_javaagent-<version>.jar.sha256` asset)."
+      ]
+    },
     {
       "matchManagers": ["ansible-galaxy"],
       "groupName": "ansible-galaxy collections",

--- a/roles/opennms_core/defaults/main.yml
+++ b/roles/opennms_core/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 opennms_distribution: Horizon
+# renovate: datasource=github-tags depName=OpenNMS/opennms extractVersion=^opennms-(?<version>\d+\.\d+\.\d+)-\d+$
 opennms_version: 36.0.0
 opennms_pkg_version: "{{ opennms_version }}*"
 
@@ -17,8 +18,10 @@ iplike_pkg_version: "{{ iplike_version }}.*"
 
 prom_jmx_exporter_owner: opennms
 prom_jmx_exporter_group: opennms
+# renovate: datasource=github-releases depName=prometheus/jmx_exporter extractVersion=^v?(?<version>.+)$
 prom_jmx_exporter_version: 1.5.0
-prom_jmx_exporter_url: "https://github.com/prometheus/jmx_exporter/releases/download/{{ prom_jmx_exporter_version }}/jmx_prometheus_javaagent-{{ prom_jmx_exporter_version }}.jar"
+# Upstream tags gained a "v" prefix with 1.6.0: the release path needs it, the jar name does not
+prom_jmx_exporter_url: "https://github.com/prometheus/jmx_exporter/releases/download/{{ 'v' if prom_jmx_exporter_version is version('1.6.0', '>=') else '' }}{{ prom_jmx_exporter_version }}/jmx_prometheus_javaagent-{{ prom_jmx_exporter_version }}.jar"
 prom_jmx_exporter_sha256: sha256:0315f3f657876302c6205a98d4036ec775dca529c5d0419ca60ee669c688239f
 prom_jmx_exporter_home: /opt/prom-jmx-exporter
 prom_jmx_exporter_config:

--- a/roles/opennms_minion/defaults/main.yml
+++ b/roles/opennms_minion/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 opennms_distribution: Horizon
+# renovate: datasource=github-tags depName=OpenNMS/opennms extractVersion=^opennms-(?<version>\d+\.\d+\.\d+)-\d+$
 opennms_version: 36.0.0
 opennms_pkg_version: "{{ opennms_version }}*"
 opennms_minion_home: "/opt/minion"

--- a/roles/opennms_sentinel/defaults/main.yml
+++ b/roles/opennms_sentinel/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 opennms_distribution: Horizon
+# renovate: datasource=github-tags depName=OpenNMS/opennms extractVersion=^opennms-(?<version>\d+\.\d+\.\d+)-\d+$
 opennms_version: 36.0.0
 opennms_pkg_version: "{{ opennms_version }}*"
 opennms_sentinel_home: /opt/sentinel


### PR DESCRIPTION
## Why

Renovate now keeps GitHub Actions pins and Galaxy collections current, but the component versions the roles actually deploy — `opennms_version` (36.0.0, upstream is at 36.0.2) and `prom_jmx_exporter_version` (1.5.0, upstream at 1.6.0) — were unmanaged.

## What

- **Custom manager** in `renovate.json`: one generic regex that picks up any `# renovate: datasource=... depName=...` annotation directly above a version variable in `roles/*/defaults/main.yml`. Future variables just need the annotation, no config change.
- **`opennms_version`** annotated in `opennms_core`, `opennms_minion`, `opennms_sentinel` defaults → tracked via `github-tags` on `OpenNMS/opennms`, version extracted from `opennms-X.Y.Z-N` tags. All three files update together in one PR (same depName).
- **`prom_jmx_exporter_version`** annotated → tracked via `github-releases` on `prometheus/jmx_exporter`, `v` prefix stripped.
- **Download URL fix**: jmx_exporter tags gained a `v` prefix with 1.6.0 (tag `v1.6.0`, jar `jmx_prometheus_javaagent-1.6.0.jar`), so the old template was broken for every future release. The URL now derives the tag prefix from the version.
- **Checksum guard**: Renovate PRs for jmx_exporter include a body note to update `prom_jmx_exporter_sha256` before merging (the pinned checksum must change with the jar; these PRs are not automerged). Maven Central was considered as a prefix-free source but rejected — it only carries the javaagent up to 1.0.1.

## Verification

- `renovate-config-validator` passes
- Custom-manager regex tested against all three files — extracts all 4 dependency instances with correct datasource/depName/extractVersion/currentValue
- URL template rendered via Ansible for 1.5.0 and 1.6.0; both resulting URLs return HTTP 200
- `ansible-lint` (production profile) passes on the changed files

After merge, expect Renovate PRs for OpenNMS 36.0.2 and jmx_exporter 1.6.0 (trigger a job or use the Dependency Dashboard checkboxes to get them immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)