### PR TITLE
chore(release): bump collection version to 0.4.7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,17 +98,17 @@ Templates for OpenNMS config go in `roles/opennms_core/templates/etc/opennms.pro
 
 External collections (`requirements.yml`):
 - `community.postgresql` v4.2.0 — used by `stub_pgsql` and `opennms_core` for database setup
-- `community.general` v12.5.0 — general utilities
-- `grafana.grafana` v6.0.6 — Grafana installation and provisioning
+- `community.general` v13.2.0 — general utilities
+- `grafana.grafana` v6.1.0 — Grafana installation and provisioning
 
 ## Key Versions
 
 | Component | Version |
 |-----------|---------|
-| OpenNMS Horizon | 36.0.0 |
+| OpenNMS Horizon | 36.0.2 |
 | PostgreSQL | 18 |
 | Kafka | 4.2.0 (KRaft) |
 | OpenJDK | 21 |
 | Grafana | 12.x |
 | Grafana Mimir | 3.0.4 |
-| Prometheus JMX Exporter | 1.5.0 |
+| Prometheus JMX Exporter | 1.6.0 |

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: indigo423
 name: opennms
-version: 0.4.6
+version: 0.4.7
 readme: README.md
 authors:
   - Ronny Trommer <ronny@no42.org>


### PR DESCRIPTION
Version bump for the v0.4.7 release (galaxy-release workflow verifies the tag against `galaxy.yml`), plus refreshing CLAUDE.md's stale version references to match what the roles now deploy.

Release contents since v0.4.6: OpenNMS Horizon 36.0.2, jmx_exporter 1.6.0, Renovate-managed component versions, and three deployment fixes validated by an end-to-end smoke test (#109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)