### PR TITLE
fix(opennms_core): fail the play when install -dis schema migration fails

### DIFF
--- a/roles/opennms_core/tasks/10-database-setup.yml
+++ b/roles/opennms_core/tasks/10-database-setup.yml
@@ -163,7 +163,11 @@
     ADDITIONAL_MANAGER_OPTIONS: "-Dopennms.postgresql.maxVersion={{ (pg_version | int + 1) }}.0"
   register: database_init
   when: not initialized_schema.stat.exists
-  changed_when: database_init.rc != 0
+  # install -dis returns 0 on success and performs the schema migration, so a
+  # successful run IS a change; any non-zero rc is a migration failure that must
+  # fail the play rather than silently proceed to a broken startup.
+  changed_when: database_init.rc == 0
+  failed_when: database_init.rc != 0
   tags:
     - opennms
     - initialize


### PR DESCRIPTION
Fixes the silent migration-failure bug in `opennms_core` (see #111).

`roles/opennms_core/tasks/10-database-setup.yml` ran `bin/install -dis` with `changed_when: database_init.rc != 0` and **no `failed_when`** — so a successful migration reported *ok/unchanged*, and a **failed** migration never failed the play. The role then started OpenNMS on a half-migrated DB, surfacing later as a 5-min Liquibase-lock hang + `System.exit(1)` with no hint of the real cause.

**Change:** `changed_when: database_init.rc == 0` + `failed_when: database_init.rc != 0`.

Latent bug affecting every fresh deploy. Part of a 3-PR set hardening Core startup (#111 this, #112 readiness gate, #113 stale-lock recovery).

Closes #111