### PR TITLE
feat(opennms_core): wait for Core readiness after start

### DIFF
--- a/roles/opennms_core/tasks/main.yml
+++ b/roles/opennms_core/tasks/main.yml
@@ -68,6 +68,26 @@
     - core
     - systemd
 
+# systemd reports the unit "started" as soon as the launcher returns, but the
+# JVM/web UI take minutes to come up — and OpenNMS can still exit during that
+# window (e.g. a Liquibase changelog-lock timeout). Wait for the web UI so the
+# role only reports success once Core is actually serving, and fails clearly if
+# it never becomes ready.
+- name: Wait for OpenNMS Core to become ready
+  ansible.builtin.uri:
+    url: "http://localhost:8980/opennms/login.jsp"
+    method: GET
+    status_code: 200
+  register: opennms_core_ready
+  until: opennms_core_ready.status | default(0) == 200
+  retries: "{{ opennms_startup_retries | default(30) }}"
+  delay: "{{ opennms_startup_delay | default(10) }}"
+  when:
+    - skip_startup | default("false") == "false"
+  tags:
+    - core
+    - systemd
+
 - name: Check if UFW is installed
   ansible.builtin.command: which ufw
   register: ufw_binary_check


### PR DESCRIPTION
Adds a post-start readiness gate to `opennms_core` (see #112).

The "Start systemd unit" task returns as soon as systemd accepts the start; OpenNMS then takes minutes to serve and can exit mid-startup (e.g. the Liquibase lock timeout in #113), so the play reported **success** on a Core already going down.

**Change:** after start, poll `http://localhost:8980/opennms/login.jsp` with `until: status == 200`, `retries`/`delay` (defaults 30×10s ≈ 5 min, tunable via `opennms_startup_retries`/`opennms_startup_delay`), gated on `skip_startup`. If Core never becomes ready the play fails clearly instead of silently.

Part of the 3-PR Core-startup hardening set (#111, #112, #113).

Closes #112