### PR TITLE
fix(opennms_core): clear stale Liquibase changelog lock before startup

### DIFF
--- a/roles/opennms_core/tasks/10-database-setup.yml
+++ b/roles/opennms_core/tasks/10-database-setup.yml
@@ -168,3 +168,37 @@
     - opennms
     - initialize
     - database
+
+# On startup OpenNMS runs Liquibase, which takes the databasechangeloglock row.
+# A prior interrupted install/start can leave it held, making the next start
+# wait Liquibase's default 5 minutes and then System.exit(1). Reset a stale lock
+# here (after schema init, so the table exists) so startup self-heals. The DO
+# guard makes it a no-op if the table is not present yet.
+- name: Ensure psycopg2 is available for the changelog-lock reset
+  ansible.builtin.apt:
+    name: python3-psycopg2
+    state: present
+  tags:
+    - opennms
+    - database
+
+- name: Clear a stale Liquibase changelog lock before startup
+  community.postgresql.postgresql_query:
+    login_host: "{{ opennms_datasource_db_host }}"
+    login_port: "{{ opennms_datasource_db_port | default(5432) }}"
+    login_user: "{{ postgres_user }}"
+    login_password: "{{ postgres_password }}"
+    db: "{{ opennms_datasource_db_name }}"
+    query: |
+      DO $$
+      BEGIN
+        IF to_regclass('public.databasechangeloglock') IS NOT NULL THEN
+          UPDATE databasechangeloglock
+          SET locked = false, lockgranted = NULL, lockedby = NULL;
+        END IF;
+      END $$;
+  changed_when: false
+  no_log: true
+  tags:
+    - opennms
+    - database


### PR DESCRIPTION
Makes `opennms_core` self-heal from a stale Liquibase changelog lock (see #113).

A prior interrupted `install -dis` or Core start can leave `databasechangeloglock` held; the next start then waits Liquibase's default **5 min** and `System.exit(1)`s, so the deploy hangs until the lock is cleared by hand.

**Change:** after schema init (table exists), reset a stale lock via `community.postgresql.postgresql_query`. A `DO` guard makes it a no-op if the table isn't present; idempotent otherwise (a healthy row is already `locked=false`).

Notes for review: connects from the Core host to the OpenNMS DB using the admin creds the role already holds; adds `python3-psycopg2` for the query module. Happy to switch to `delegate_to` the DB host if preferred. Part of the 3-PR Core-startup hardening set (#111, #112, #113).

Closes #113