### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the `indigo423.opennms` collection are documented in this
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each entry below is a short index; the corresponding GitHub release contains the full notes including the Component Versions table and upgrade instructions.
 
+## [0.5.0] - 2026-07-25
+
+### Added
+- `opennms_core`: wait for Core to answer on `http://localhost:8980/opennms/login.jsp` after the systemd unit starts, instead of returning as soon as systemd accepts the start. Core needs minutes to serve and can exit mid-startup, so the play previously reported success on a Core that was already going down. Tunable via `opennms_startup_retries` (30) and `opennms_startup_delay` (10s, ≈5 min total); skipped when `skip_startup` is set (#112).
+
+### Fixed
+- `opennms_core`: fail the play when `bin/install -dis` fails. The task ran with `changed_when: rc != 0` and no `failed_when`, so a successful schema migration reported *ok/unchanged* and a **failed** one never failed the play — the role went on to start OpenNMS against a half-migrated database, surfacing later as a 5-minute Liquibase-lock hang and `System.exit(1)` with nothing pointing at the real cause (#111).
+- `opennms_core`: clear a stale Liquibase changelog lock before startup. An interrupted `install -dis` or Core start can leave `databasechangeloglock` held, making the next start wait out Liquibase's 5-minute default and then `System.exit(1)` — the deploy hung until someone cleared the lock by hand. The role now resets a stale lock after schema init, guarded by a `DO` block so it is a no-op when the table is absent and idempotent otherwise. Adds `python3-psycopg2` to the Core host for the query (#113).
+
+## [0.4.7] - 2026-07-17
+
+### Changed
+- Bump OpenNMS Horizon to `36.0.2` and Prometheus JMX Exporter to `1.6.0`; both are now Renovate-managed so future bumps arrive automatically (#107, #108).
+- `stub_kafka`: download Kafka from `archive.apache.org` instead of `dlcdn.apache.org`. The CDN drops superseded releases, so any pinned `kafka_version` starts 404ing as soon as upstream moves on — `4.2.0` was already gone (#109).
+
+### Fixed
+- `opennms_repositories`: install `gnupg`. Minimal cloud images ship without it, and every repository-key task needs it; standard server images masked the gap. Installed here rather than in `common` so the targeted `hzn-*-deployment.yml` playbooks and standalone Galaxy consumers are covered too (#109).
+- `opennms_core`: run `scvcli` through `bash`. The packaged script reads `java.conf` with the bash-only `$(<file)` expansion under a `#!/bin/sh` shebang, which yields an empty Java path on Debian/Ubuntu where `sh` is dash — breaking vault init with `-jar: not found` (#109).
+
 ## [0.4.6] - 2026-05-29
 
 ### Fixed
@@ -96,6 +115,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Renovate configuration for automated Ansible Galaxy collection updates.
 - CI on standard GitHub-hosted runners with SHA-pinned actions and Dependabot.
 
+[0.5.0]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.5.0
+[0.4.7]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.4.7
+[0.4.6]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.4.6
+[0.4.5]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.4.5
+[0.4.4]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.4.4
+[0.4.3]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.4.3
+[0.4.2]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.4.2
+[0.4.1]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.4.1
 [0.4.0]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.4.0
 [0.3.2]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.3.2
 [0.3.1]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.3.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ ansible-playbook -i inventory/opennms-stack.yml hzn-sentinel-deployment.yml
 - `opennms_repositories` — APT repo and GPG key setup; must run before any package install
 - `openjdk` — Installs OpenJDK 21 for OpenNMS components and Kafka
 - `common` — Timezone, APT cache update, base system packages
-- `opennms_core` — OpenNMS Horizon Core (36.0.0): database init, Kafka config, JVM tuning, firewall rules
+- `opennms_core` — OpenNMS Horizon Core (36.0.2): database init, Kafka config, JVM tuning, firewall rules
 - `opennms_minion` — Minion agent for isolated network segments
 - `opennms_sentinel` — Flow persistence and aggregation
 - `opennms_icmp` — ICMP monitoring configuration

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: indigo423
 name: opennms
-version: 0.4.7
+version: 0.5.0
 readme: README.md
 authors:
   - Ronny Trommer <ronny@no42.org>


### PR DESCRIPTION
Release-prep for **v0.5.0**. `galaxy-release.yml` verifies `galaxy.yml`'s `version` against the tag, so this must land on `main` before tagging.

## Why MINOR, not PATCH

Three PRs landed since v0.4.7, one of them a `feat` (#115, the post-start readiness gate). `RELEASING.md` scopes MINOR to new roles / opt-in features / bumps needing user action — none of which strictly applies — but the gate does change deploy behaviour (a Core that never becomes ready now fails the play instead of passing), so consumers deserve the MINOR signal.

## Changes

- `galaxy.yml` — `0.4.7` → `0.5.0`.
- `CHANGELOG.md` — new `0.5.0` section for the Core-startup hardening set (#111, #112, #113).
- `CHANGELOG.md` — **backfills `0.4.7`**, which shipped without an entry, and adds the link references missing since `0.4.1`.
- `CLAUDE.md` — the role list still said Horizon `36.0.0` while the table and role defaults say `36.0.2` (`RELEASING.md` requires these in sync).

## Verification

```
$ ansible-lint
Passed: 0 failure(s), 0 warning(s) in 110 files processed of 133 encountered.
Profile 'production' was required, and it passed.

$ ansible-galaxy collection build
Created collection for indigo423.opennms at .../indigo423-opennms-0.5.0.tar.gz
```

No role logic touched — version metadata and docs only.