### PR TITLE
feat: add stub_victoriametrics role (single-node VictoriaMetrics backend)

### DIFF
--- a/roles/stub_victoriametrics/README.md
+++ b/roles/stub_victoriametrics/README.md
@@ -1,0 +1,6 @@
+# stub_victoriametrics
+
+Benchmark **stub** role: installs a single-node VictoriaMetrics from the upstream
+release tarball and runs it as a systemd service on `:8428`. Intended as an
+OpenNMS time-series backend via the Prometheus `remote_write` plugin (same plugin
+as Mimir; see `opennms_core`). Not a production-grade VictoriaMetrics deployment.

--- a/roles/stub_victoriametrics/defaults/main.yml
+++ b/roles/stub_victoriametrics/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# renovate: datasource=github-releases depName=VictoriaMetrics/VictoriaMetrics
+victoriametrics_version: "1.148.0"
+victoriametrics_arch: amd64
+victoriametrics_pkg_url: "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v{{ victoriametrics_version }}/victoria-metrics-linux-{{ victoriametrics_arch }}-v{{ victoriametrics_version }}.tar.gz"
+victoriametrics_http_port: 8428
+victoriametrics_data_path: /var/lib/victoria-metrics
+victoriametrics_retention: "1d"

--- a/roles/stub_victoriametrics/handlers/main.yml
+++ b/roles/stub_victoriametrics/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart victoriametrics
+  ansible.builtin.systemd:
+    name: victoria-metrics.service
+    state: restarted
+    daemon_reload: true

--- a/roles/stub_victoriametrics/meta/main.yml
+++ b/roles/stub_victoriametrics/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: stub_victoriametrics
+  author: Ronny Trommer
+  description: POC/test stub that deploys single-node VictoriaMetrics for OpenNMS time-series storage. Not for production use.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - victoriametrics
+    - metrics
+    - stub
+
+dependencies: []

--- a/roles/stub_victoriametrics/tasks/main.yml
+++ b/roles/stub_victoriametrics/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+- name: Create the victoriametrics system group
+  ansible.builtin.group:
+    name: victoriametrics
+    system: true
+  tags:
+    - victoriametrics
+
+- name: Create the victoriametrics system user
+  ansible.builtin.user:
+    name: victoriametrics
+    group: victoriametrics
+    system: true
+    shell: /usr/sbin/nologin
+    home: "{{ victoriametrics_data_path }}"
+    create_home: false
+  tags:
+    - victoriametrics
+
+- name: Create the VictoriaMetrics data directory
+  ansible.builtin.file:
+    path: "{{ victoriametrics_data_path }}"
+    state: directory
+    owner: victoriametrics
+    group: victoriametrics
+    mode: "0750"
+  tags:
+    - victoriametrics
+
+- name: Install the victoria-metrics-prod binary
+  ansible.builtin.unarchive:
+    src: "{{ victoriametrics_pkg_url }}"
+    dest: /usr/local/bin
+    remote_src: true
+    creates: /usr/local/bin/victoria-metrics-prod
+    owner: root
+    group: root
+    mode: "0755"
+  tags:
+    - victoriametrics
+
+- name: Install the VictoriaMetrics systemd unit
+  ansible.builtin.template:
+    src: victoria-metrics.service.j2
+    dest: /etc/systemd/system/victoria-metrics.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart victoriametrics
+  tags:
+    - victoriametrics
+    - systemd
+
+- name: Enable and start VictoriaMetrics
+  ansible.builtin.systemd:
+    name: victoria-metrics.service
+    enabled: true
+    state: started
+    daemon_reload: true
+  tags:
+    - victoriametrics
+    - systemd

--- a/roles/stub_victoriametrics/templates/victoria-metrics.service.j2
+++ b/roles/stub_victoriametrics/templates/victoria-metrics.service.j2
@@ -1,0 +1,19 @@
+# Managed by Ansible (indigo423.opennms.stub_victoriametrics)
+[Unit]
+Description=VictoriaMetrics single-node time-series database
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=victoriametrics
+Group=victoriametrics
+ExecStart=/usr/local/bin/victoria-metrics-prod \
+  -storageDataPath={{ victoriametrics_data_path }} \
+  -httpListenAddr=:{{ victoriametrics_http_port }} \
+  -retentionPeriod={{ victoriametrics_retention }}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
New benchmark **stub** role: installs single-node VictoriaMetrics from the upstream release tarball and runs it as a systemd service on `:8428` — a time-series backend for OpenNMS via the Prometheus remote_write plugin (companion to the `opennms_core` remote_write PR; same plugin as Mimir, different `write_url`).

All-new files (no changes to existing roles). Follows the `stub_mimir` pattern. **Verified end-to-end** on a live KVM lab: OpenNMS wrote 549 series to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)