### PR TITLE
fix(opennms_core): harden Phase 3a remote_write/TSDB roles after review

### DIFF
--- a/roles/opennms_core/tasks/22-timeseries-plugin.yml
+++ b/roles/opennms_core/tasks/22-timeseries-plugin.yml
@@ -1,8 +1,11 @@
 ---
 # Install + configure the opennms-prometheus-remotewrite-plugin so OpenNMS writes
 # metrics to any Prometheus remote_write backend (Mimir, VictoriaMetrics, ...).
-# The time-series strategy itself (org.opennms.timeseries.strategy=integration)
-# is set via opennms_properties_timeseries (see 20-config.yml).
+# This task also sets the time-series strategy to the integration layer via
+# _ansible.remotewrite.properties (org.opennms.timeseries.strategy=integration).
+# Note: the default opennms_properties_timeseries dict still renders the RRD
+# strategy/graph-engine props in 20-config.yml; under the integration strategy
+# those RRD settings are inert, but they are not removed here.
 - name: Enable the OSGi time-series integration layer for remote_write
   ansible.builtin.template:
     src: etc/opennms.properties.d/_ansible.remotewrite.properties.j2
@@ -15,13 +18,39 @@
     - core
     - timeseries
 
+# The KAR filename carries the plugin version so bumping opennms_remotewrite_version
+# lands a new artifact instead of silently reusing the old one (get_url only
+# downloads when dest is absent). Superseded KARs are removed first so Karaf never
+# has two versions of the feature in deploy/ at once.
+- name: Remove superseded Prometheus remote_write plugin KARs
+  ansible.builtin.find:
+    paths: "{{ opennms_home }}/deploy"
+    patterns: "opennms-prometheus-remotewrite-plugin-*.kar"
+    excludes: "opennms-prometheus-remotewrite-plugin-{{ opennms_remotewrite_version }}.kar"
+  register: opennms_remotewrite_stale_kars
+  tags:
+    - core
+    - timeseries
+
+- name: Delete superseded Prometheus remote_write plugin KARs
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ opennms_remotewrite_stale_kars.files }}"
+  loop_control:
+    label: "{{ item.path }}"
+  notify: Restart opennms
+  tags:
+    - core
+    - timeseries
+
 - name: Download the Prometheus remote_write plugin KAR
   ansible.builtin.get_url:
     url: "{{ opennms_remotewrite_kar_url }}"
-    dest: "{{ opennms_home }}/deploy/opennms-prometheus-remotewrite-plugin.kar"
+    dest: "{{ opennms_home }}/deploy/opennms-prometheus-remotewrite-plugin-{{ opennms_remotewrite_version }}.kar"
     owner: opennms
     group: opennms
-    mode: "0644"
+    mode: "0640"
   notify: Restart opennms
   tags:
     - core
@@ -33,7 +62,7 @@
     content: "{{ opennms_remotewrite_feature }}\n"
     owner: opennms
     group: opennms
-    mode: "0644"
+    mode: "0640"
   notify: Restart opennms
   tags:
     - core
@@ -45,7 +74,7 @@
     dest: "{{ opennms_home }}/etc/org.opennms.plugins.tss.prometheus.cfg"
     owner: opennms
     group: opennms
-    mode: "0644"
+    mode: "0640"
   notify: Restart opennms
   tags:
     - core

--- a/roles/opennms_core/tasks/main.yml
+++ b/roles/opennms_core/tasks/main.yml
@@ -46,13 +46,13 @@
 - name: Include tasks configuring the core system
   ansible.builtin.include_tasks: 20-config.yml
 
-- name: Configure the Prometheus remote_write time-series plugin
-  ansible.builtin.include_tasks: 22-timeseries-plugin.yml
-  when: opennms_remotewrite.enabled | default(false) | bool
-
 - name: Configure Kafka as message broker
   ansible.builtin.include_tasks: 21-kafka.yml
   when: opennms_message_broker == "kafka"
+
+- name: Configure the Prometheus remote_write time-series plugin
+  ansible.builtin.include_tasks: 22-timeseries-plugin.yml
+  when: opennms_remotewrite.enabled | default(false) | bool
 
 - name: Enable systemd unit for OpenNMS {{ opennms_distribution }}
   ansible.builtin.service:

--- a/roles/stub_mimir/defaults/main.yml
+++ b/roles/stub_mimir/defaults/main.yml
@@ -4,3 +4,12 @@ mimir_arch: amd64
 mimir_pkg_url: "https://github.com/grafana/mimir/releases/download/mimir-{{ mimir_version }}/mimir-{{ mimir_version }}_{{ mimir_arch }}.deb"
 mimir_http_port: 8080
 mimir_data_dir: /var/lib/mimir
+
+# Per-tenant limits for the single anonymous tenant (multitenancy disabled).
+# Mimir's defaults (ingestion_rate ~10k samples/s, max_global_series_per_user
+# ~150k) throttle and 429 a large benchmark; raise them so a 10k-node OpenNMS
+# remote_write load is measured un-throttled (0 = unlimited for the series caps).
+mimir_ingestion_rate: 1000000
+mimir_ingestion_burst_size: 2000000
+mimir_max_global_series_per_user: 0
+mimir_max_global_series_per_metric: 0

--- a/roles/stub_mimir/handlers/main.yml
+++ b/roles/stub_mimir/handlers/main.yml
@@ -3,3 +3,6 @@
   ansible.builtin.service:
     name: mimir.service
     state: restarted
+  tags:
+    - mimir
+    - systemd

--- a/roles/stub_mimir/templates/config.yml.j2
+++ b/roles/stub_mimir/templates/config.yml.j2
@@ -5,6 +5,11 @@ multitenancy_enabled: false
 server:
   http_listen_port: {{ mimir_http_port }}
   log_level: warn
+limits:
+  ingestion_rate: {{ mimir_ingestion_rate }}
+  ingestion_burst_size: {{ mimir_ingestion_burst_size }}
+  max_global_series_per_user: {{ mimir_max_global_series_per_user }}
+  max_global_series_per_metric: {{ mimir_max_global_series_per_metric }}
 blocks_storage:
   backend: filesystem
   filesystem:

--- a/roles/stub_victoriametrics/handlers/main.yml
+++ b/roles/stub_victoriametrics/handlers/main.yml
@@ -4,3 +4,6 @@
     name: victoria-metrics.service
     state: restarted
     daemon_reload: true
+  tags:
+    - victoriametrics
+    - systemd

--- a/roles/stub_victoriametrics/tasks/main.yml
+++ b/roles/stub_victoriametrics/tasks/main.yml
@@ -27,15 +27,38 @@
   tags:
     - victoriametrics
 
-- name: Install the victoria-metrics-prod binary
-  ansible.builtin.unarchive:
-    src: "{{ victoriametrics_pkg_url }}"
-    dest: /usr/local/bin
-    remote_src: true
-    creates: /usr/local/bin/victoria-metrics-prod
+# Unpack into a version-scoped directory and expose it through a stable symlink,
+# so bumping victoriametrics_version extracts the new binary (the version-independent
+# creates: guard on /usr/local/bin/victoria-metrics-prod would otherwise skip it) and
+# flips the symlink to trigger a restart.
+- name: Create the VictoriaMetrics versioned install directory
+  ansible.builtin.file:
+    path: "/opt/victoria-metrics/{{ victoriametrics_version }}"
+    state: directory
     owner: root
     group: root
     mode: "0755"
+  tags:
+    - victoriametrics
+
+- name: Install the victoria-metrics-prod binary
+  ansible.builtin.unarchive:
+    src: "{{ victoriametrics_pkg_url }}"
+    dest: "/opt/victoria-metrics/{{ victoriametrics_version }}"
+    remote_src: true
+    creates: "/opt/victoria-metrics/{{ victoriametrics_version }}/victoria-metrics-prod"
+    owner: root
+    group: root
+    mode: "0755"
+  tags:
+    - victoriametrics
+
+- name: Link victoria-metrics-prod into PATH
+  ansible.builtin.file:
+    src: "/opt/victoria-metrics/{{ victoriametrics_version }}/victoria-metrics-prod"
+    dest: /usr/local/bin/victoria-metrics-prod
+    state: link
+  notify: Restart victoriametrics
   tags:
     - victoriametrics
 


### PR DESCRIPTION
Post-merge review follow-ups for the Phase 3a work (#118 remote_write, #119 stub_victoriametrics, #120 stub_mimir), applied before the roles are cut into a release. A `medium` code review turned up 7 findings; all are fixed here.

## Correctness — version-bump idempotency traps
- **remote_write KAR never re-downloaded on a version bump** — `get_url` wrote a version-independent `opennms-prometheus-remotewrite-plugin.kar` and only downloads when `dest` is absent, so bumping `opennms_remotewrite_version` silently kept the old plugin. Now the filename carries the version and superseded KARs are removed first (so Karaf never has two feature versions in `deploy/`).
- **VictoriaMetrics binary never re-extracted on a bump** — `unarchive` guarded on a version-independent `creates:` path. Now unpacks into `/opt/victoria-metrics/<version>/` and symlinks into PATH, so a bump re-extracts and flips the symlink (→ restart).

## Benchmark validity
- **Mimir default limits throttle a 10k-node load** — with multitenancy off, the anonymous tenant hit the default `ingestion_rate` (~10k samples/s) and `max_global_series_per_user` (~150k), 429ing and dropping samples versus VictoriaMetrics (no such caps), skewing the cross-engine comparison. Added a `limits:` block (configurable via new `mimir_*` defaults; series caps default to unlimited).

## `--tags` correctness
- **Restart handlers were untagged** — under `--tags mimir` / `--tags victoriametrics` the config task fired but the untagged handler was skipped, leaving the service on stale config. Both `Restart mimir` and `Restart victoriametrics` now carry `<role>` + `systemd` tags, matching every other handler in the repo.

## Polish
- Corrected the stale header comment in `22-timeseries-plugin.yml` (the integration strategy is set by this task, not `20-config.yml`).
- Tightened the plugin cfg / boot / KAR to `0640` to match sibling files.
- Reordered the `21-kafka` / `22-timeseries` includes in `main.yml` so execution order matches the numeric task-file prefixes.

## Verification
`ansible-lint` (profile `production`) passes: 0 failures across the collection.