### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the `indigo423.opennms` collection are documented in this
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each entry below is a short index; the corresponding GitHub release contains the full notes including the Component Versions table and upgrade instructions.
 
+## [0.6.0] - 2026-07-25
+
+### Added
+- `opennms_core`: persist metrics to any Prometheus remote_write backend (Mimir, VictoriaMetrics, Cortex, Thanos) via the `opennms-prometheus-remotewrite-plugin`. New `22-timeseries-plugin.yml` downloads the plugin KAR, boots the Karaf feature, and templates the `org.opennms.plugins.tss.prometheus` PID; the time-series strategy is switched to `integration` through the existing `opennms_properties_timeseries` mechanism. Opt-in via `opennms_remotewrite.enabled` (default `false`), with `write_url`/`read_url`/`organization_id` and a Renovate-managed `opennms_remotewrite_version` (`2.1.0`) (#118).
+- `stub_victoriametrics`: new stub role deploying single-node VictoriaMetrics (`1.148.0`) as a remote_write backend, with a systemd unit, configurable `victoriametrics_http_port` (8428), `victoriametrics_data_path`, and `victoriametrics_retention` (#119).
+
+### Fixed
+- `stub_mimir`: ship a working single-node monolithic config. The role installed the Mimir `.deb` and left its empty default config in place, so Mimir started with `replication_factor: 3` against a single ingester and answered every request with `too many unhealthy instances in the ring` / HTTP 503 — never a usable backend. Now templates `/etc/mimir/config.yml` (the path the deb's unit reads) with in-memory rings, `replication_factor: 1`, and per-component filesystem storage in distinct directories. New `mimir_http_port`/`mimir_data_dir` defaults and a `Restart mimir` handler (#120).
+- `opennms_core`, `stub_victoriametrics`: make version bumps actually take effect. The plugin KAR was downloaded to a version-independent filename, so `get_url` skipped the download once the file existed and raising `opennms_remotewrite_version` was a silent no-op; the KAR filename is now versioned and superseded KARs are removed. `stub_victoriametrics` had the same trap in its `creates:` guard — the tarball now unpacks into a version-scoped directory with a symlink into `PATH`, so a bump re-extracts (#121).
+- `stub_mimir`: raise the per-tenant limits (`ingestion_rate`, series caps) for the `anonymous` tenant. Mimir's defaults returned HTTP 429 and dropped samples under a 10k-node load, skewing cross-engine comparisons against VictoriaMetrics (#121).
+- `stub_mimir`, `stub_victoriametrics`: tag the `Restart mimir` and `Restart victoriametrics` handlers so `--tags`-filtered runs still restart the service after a config change (#121).
+- `opennms_core`: tighten the remote_write plugin's cfg/boot/KAR files to `0640` to match sibling managed files, correct a stale header comment, and order the `21-kafka`/`22-timeseries-plugin` includes to match their numeric task-file prefixes (#121).
+
 ## [0.5.0] - 2026-07-25
 
 ### Added
@@ -115,6 +128,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Renovate configuration for automated Ansible Galaxy collection updates.
 - CI on standard GitHub-hosted runners with SHA-pinned actions and Dependabot.
 
+[0.6.0]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.6.0
 [0.5.0]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.5.0
 [0.4.7]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.4.7
 [0.4.6]: https://github.com/opennms-forge/ansible-opennms/releases/tag/v0.4.6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Ansible collection for deploying OpenNMS Horizon monitoring infrastructure on Debian/Ubuntu systems. Supports single-node and distributed topologies. Not yet production-ready — stub roles (PostgreSQL, Kafka, Elasticsearch, Grafana, Mimir) are for POC/testing only.
+Ansible collection for deploying OpenNMS Horizon monitoring infrastructure on Debian/Ubuntu systems. Supports single-node and distributed topologies. Not yet production-ready — stub roles (PostgreSQL, Kafka, Elasticsearch, Grafana, Mimir, VictoriaMetrics) are for POC/testing only.
 
 **Design constraint**: Roles only configure system-level files, not settings modifiable via web UI or APIs.
 
@@ -68,7 +68,8 @@ ansible-playbook -i inventory/opennms-stack.yml hzn-sentinel-deployment.yml
 - `stub_pgsql` — PostgreSQL 18 with OpenNMS database/user
 - `stub_kafka` — Kafka 4.2.0 in KRaft mode
 - `stub_elasticsearch` — Elasticsearch for flow data
-- `stub_mimir` — Grafana Mimir 3.0.4
+- `stub_mimir` — Grafana Mimir 3.0.4, single-node monolithic mode
+- `stub_victoriametrics` — VictoriaMetrics 1.148.0, single-node
 
 **External collection roles** (replacing stubs where mature alternatives exist):
 - `grafana.grafana.grafana` — Grafana 12.x (replaces `stub_grafana`); configured via `inventory/group_vars/grafana/vars.yml`
@@ -90,6 +91,7 @@ Role defaults live in `roles/<role>/defaults/main.yml`.
 - `10-database-setup.yml` — PostgreSQL schema init via `community.postgresql`
 - `20-config.yml` — Core configuration files
 - `21-kafka.yml` — Kafka IPC configuration
+- `22-timeseries-plugin.yml` — Prometheus remote_write time-series plugin (opt-in via `opennms_remotewrite.enabled`)
 - `50-firewall.yml` — UFW rules
 
 Templates for OpenNMS config go in `roles/opennms_core/templates/etc/opennms.properties.d/`.
@@ -111,4 +113,6 @@ External collections (`requirements.yml`):
 | OpenJDK | 21 |
 | Grafana | 12.x |
 | Grafana Mimir | 3.0.4 |
+| VictoriaMetrics | 1.148.0 |
 | Prometheus JMX Exporter | 1.6.0 |
+| OpenNMS Prometheus remote_write plugin | 2.1.0 |

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: indigo423
 name: opennms
-version: 0.5.0
+version: 0.6.0
 readme: README.md
 authors:
   - Ronny Trommer <ronny@no42.org>


### PR DESCRIPTION
Release-prep for **v0.6.0**. `galaxy-release.yml` verifies `galaxy.yml`'s `version` against the tag, so this must land on `main` before tagging.

## Why MINOR, not PATCH

Four commits landed since v0.5.0, two of them `feat`: the `opennms_core` Prometheus remote_write time-series backend (#118) and the new `stub_victoriametrics` role (#119). `RELEASING.md` scopes MINOR to new roles and new opt-in features — both apply here.

Nothing breaking: the diff since v0.5.0 is **+347/-0**, and `opennms_remotewrite.enabled` defaults to `false`, so existing inventories behave identically after upgrade.

## Changes

- `galaxy.yml` — `0.5.0` → `0.6.0`.
- `CHANGELOG.md` — new `0.6.0` section for the Phase 3a remote_write/TSDB set (#118, #119, #120, #121), plus the link reference.
- `CLAUDE.md` — `stub_victoriametrics` added to the stub-role list and the overview sentence; `22-timeseries-plugin.yml` added to the `opennms_core` task layout; VictoriaMetrics `1.148.0` and the OpenNMS Prometheus remote_write plugin `2.1.0` added to Key Versions (`RELEASING.md` requires these in sync).

No other component version drift since v0.5.0 — Horizon `36.0.2`, PostgreSQL `18`, Kafka `4.2.0`, OpenJDK `21`, Mimir `3.0.4`, JMX Exporter `1.6.0` all unchanged.

## Verification

```
$ ansible-lint
Passed: 0 failure(s), 0 warning(s) in 120 files processed of 144 encountered.
Profile 'production' was required, and it passed.

$ ansible-galaxy collection build
Created collection for indigo423.opennms at .../indigo423-opennms-0.6.0.tar.gz
```

The built artifact contains `roles/stub_victoriametrics/` and `roles/opennms_core/tasks/22-timeseries-plugin.yml`.

No role logic touched — version metadata and docs only.