### PR TITLE
fix(galaxy): exclude gitignored working dirs from build_ignore

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -31,3 +31,15 @@ build_ignore:
   - inventory
   - CLAUDE.md
   - RELEASING.md
+  # Gitignored working directories. CI publishes from a clean checkout and never
+  # sees these, but the manual-fallback publish in RELEASING.md runs from a
+  # working tree — without these entries it ships local IDE/agent state, and
+  # .ansible bundles a nested stale copy of this collection inside its own
+  # artifact. A published Galaxy version cannot be withdrawn, so exclude at build.
+  - .ansible          # local collection install root (collection install -r)
+  - .claude           # agent config, incl. settings.local.json
+  - .idea
+  - '*.iml'
+  - _bmad
+  - _bmad-output
+  - openspec


### PR DESCRIPTION
`ansible-galaxy collection build` packages everything in the collection root that `build_ignore` doesn't exclude — it does **not** read `.gitignore`.

CI publishes from a clean checkout, so every artifact on Galaxy is correct and no released version is affected. But the manual-fallback publish documented in `RELEASING.md` runs from a working tree, and there the same command bundled every local working directory.

## What was leaking

Measured by building from this working tree, which has all of these populated:

| Path | Leaked | Why it matters |
|---|---|---|
| `.ansible` | 1107 entries | The local collection install root — the artifact contained a nested stale copy of this collection inside itself |
| `.claude` | ~350 files | Agent config, **including `settings.local.json`** |
| `.idea`, `*.iml` | 9 files | IDE state incl. `workspace.xml` |
| `_bmad`, `_bmad-output`, `openspec` | empty here | Populated on other checkouts |

A published Galaxy version cannot be withdrawn, so one fallback publish would have leaked local settings permanently.

## Verification

Built from this working tree, before → after:

```
$ tar tzf indigo423-opennms-0.6.0.tar.gz | grep -c '^\.ansible/'
1107   ->   0
```

Zero entries for every excluded path (`.ansible/`, `.claude/`, `.idea/`, `*.iml`, `_bmad`, `openspec/`), and the artifact drops from **2.9 MB to 73 KB**.

Still shipped, confirmed present: all **13 roles**, `.ansible-lint`, `.github/workflows/`, `.gitignore`, `LICENSE`, `README.md`, `CHANGELOG.md`. The `- .ansible` pattern is an exact match, so `.ansible-lint` is unaffected.

Cross-checked against the artifact Galaxy actually received for v0.6.0 (downloaded from the Galaxy API): **207 entries each, identical except one empty directory** — CI's has `dist/`, the local build has `docs/`. The residual 2.6 KB size delta is content-level (this `galaxy.yml` grew by the new block, plus `FILES.json` checksums and gzip variance), not extra files.

## Not changed here

CI's published artifact contains an empty `dist/` directory, because `--output-path dist/` writes inside the collection root. Cosmetic, and `dist` isn't gitignored either — happy to add `dist` to both `.gitignore` and `build_ignore` in a follow-up if you want it gone.

No release needed for this; it rides the next one.