### PR TITLE
ci: run lint on pull_request, scope push to main

### DIFF
--- a/.github/workflows/ansible-opennms-lint.yml
+++ b/.github/workflows/ansible-opennms-lint.yml
@@ -3,7 +3,13 @@ name: ansible-opennms-lint
 run-name: Validate the Ansible playbook
 on:
   workflow_dispatch:
+  # Fork PRs never fire `push` in this repo, so a push-only trigger left the
+  # required `ansible-lint` check permanently pending on outside contributions.
+  # Scoping push to main and adding pull_request gives one run per PR and one
+  # per merge, instead of two runs for every branch push.
   push:
+    branches: [main]
+  pull_request:
 
 jobs:
   ansible-lint:


### PR DESCRIPTION
`ansible-opennms-lint.yml` triggered on `push` (all branches) and `workflow_dispatch` only.

Branches in this repo produce a check run via the push event — which is why #122 and #123 both showed green. But a **fork PR never fires `push` here**, so no `ansible-lint` check would ever appear on it.

That turned into a hard block when the `protected-main` ruleset was enabled with `ansible-lint` as a required status check: an outside contributor's PR would sit with the required check permanently pending, unmergeable, with nothing to retry.

## Change

```yaml
on:
  workflow_dispatch:
  push:
    branches: [main]
  pull_request:
```

- `pull_request` — the check now reports on every PR regardless of origin.
- `push` scoped to `main` — a branch push no longer duplicates the run.

Net: **one run per PR, one per merge to main** — instead of two runs for every branch push.

## Verification

```
$ python3 -c "import yaml; ..."
triggers: {'workflow_dispatch': None, 'push': {'branches': ['main']}, 'pull_request': None}
jobs    : ['ansible-lint']

$ actionlint .github/workflows/ansible-opennms-lint.yml
clean
```

The **job name is unchanged** (`ansible-lint`), so the ruleset's required-status-check context still matches — this PR is itself the proof, since it can only merge if that check reports.

This PR should show exactly one `ansible-lint` run, from the `pull_request` event: the branch push no longer triggers the workflow, because the workflow file at that commit already scopes `push` to `main`.