### PR TITLE
feat(stub_clickhouse): single-node ClickHouse for the Akvorado flow path

### DIFF
--- a/roles/stub_clickhouse/README.md
+++ b/roles/stub_clickhouse/README.md
@@ -1,0 +1,45 @@
+# stub_clickhouse
+
+Benchmark **stub** role: installs a single-node ClickHouse from the upstream apt
+repository and runs it as a systemd service on `:8123` (HTTP) and `:9000`
+(native). Intended as the flow-storage backend for `akvorado`, which creates and
+migrates its own schema. Not a production-grade ClickHouse deployment.
+
+## What it does
+
+- Adds the ClickHouse apt repository (`packages.clickhouse.com/deb stable`).
+- Installs `clickhouse-common-static`, `clickhouse-server` and `clickhouse-client`,
+  all pinned to the same `clickhouse_version` — the server refuses to start
+  against a mismatched `clickhouse-common-static`.
+- Drops `/etc/clickhouse-server/config.d/10-lab-listen.xml` to set the listen
+  address, ports and data path. Using `config.d` rather than editing `config.xml`
+  means a package upgrade cannot silently revert the listen address.
+
+## Not production
+
+- Listens on `0.0.0.0` so a separate Akvorado host can reach it. Acceptable only
+  because the lab sits on a private subnet.
+- Keeps the packaged `default` user with no password and applies no resource
+  limits, quotas or TLS.
+
+## Variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `clickhouse_version` | `26.7.1.1315` | Exact package version, applied to all three packages |
+| `clickhouse_http_port` | `8123` | HTTP interface |
+| `clickhouse_tcp_port` | `9000` | Native protocol |
+| `clickhouse_data_dir` | `/var/lib/clickhouse` | Storage path |
+| `clickhouse_listen_host` | `0.0.0.0` | Listen address |
+| `clickhouse_apt_key_url` | ClickHouse `repomd.xml.key` | Repository signing key (served from the `rpm/lts` path, not `deb`) |
+
+## Example
+
+```yaml
+- name: Manage ClickHouse
+  hosts: clickhouse
+  become: true
+  roles:
+    - indigo423.opennms.common
+    - indigo423.opennms.stub_clickhouse
+```

--- a/roles/stub_clickhouse/README.md
+++ b/roles/stub_clickhouse/README.md
@@ -31,6 +31,7 @@ migrates its own schema. Not a production-grade ClickHouse deployment.
 | `clickhouse_tcp_port` | `9000` | Native protocol |
 | `clickhouse_data_dir` | `/var/lib/clickhouse` | Storage path |
 | `clickhouse_listen_host` | `0.0.0.0` | Listen address |
+| `clickhouse_arch` | `amd64` | Repository architecture |
 | `clickhouse_apt_key_url` | ClickHouse `repomd.xml.key` | Repository signing key (served from the `rpm/lts` path, not `deb`) |
 
 ## Example

--- a/roles/stub_clickhouse/defaults/main.yml
+++ b/roles/stub_clickhouse/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+# renovate: datasource=deb depName=clickhouse-server
+clickhouse_version: "26.7.1.1315"
+
+clickhouse_apt_key_url: "https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key"
+clickhouse_apt_repo_uri: "https://packages.clickhouse.com/deb"
+clickhouse_apt_suite: stable
+
+clickhouse_http_port: 8123
+clickhouse_tcp_port: 9000
+clickhouse_data_dir: /var/lib/clickhouse
+
+# ClickHouse binds loopback only out of the box. Akvorado runs on a separate
+# host in this lab, so the stub listens on all interfaces — acceptable because
+# the lab sits on a private subnet, and the reason this is a stub, not a
+# production deployment.
+clickhouse_listen_host: "0.0.0.0"

--- a/roles/stub_clickhouse/defaults/main.yml
+++ b/roles/stub_clickhouse/defaults/main.yml
@@ -2,6 +2,7 @@
 # renovate: datasource=deb depName=clickhouse-server
 clickhouse_version: "26.7.1.1315"
 
+clickhouse_arch: amd64
 clickhouse_apt_key_url: "https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key"
 clickhouse_apt_repo_uri: "https://packages.clickhouse.com/deb"
 clickhouse_apt_suite: stable

--- a/roles/stub_clickhouse/handlers/main.yml
+++ b/roles/stub_clickhouse/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Restart clickhouse
+  ansible.builtin.service:
+    name: clickhouse-server.service
+    state: restarted
+  tags:
+    - clickhouse
+    - systemd

--- a/roles/stub_clickhouse/meta/main.yml
+++ b/roles/stub_clickhouse/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: stub_clickhouse
+  author: Ronny Trommer
+  description: POC/test stub that deploys single-node ClickHouse as a flow-storage backend for Akvorado. Not for production use.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - clickhouse
+    - flows
+    - stub
+
+dependencies: []

--- a/roles/stub_clickhouse/tasks/main.yml
+++ b/roles/stub_clickhouse/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+- name: Add the ClickHouse apt repository
+  ansible.builtin.deb822_repository:
+    name: clickhouse
+    types: deb
+    uris: "{{ clickhouse_apt_repo_uri }}"
+    suites: "{{ clickhouse_apt_suite }}"
+    components:
+      - main
+    architectures:
+      - amd64
+    signed_by: "{{ clickhouse_apt_key_url }}"
+  tags:
+    - clickhouse
+    - repositories
+
+# Pinned to one version across all three packages: clickhouse-server refuses to
+# start against a mismatched clickhouse-common-static.
+- name: Install ClickHouse {{ clickhouse_version }}
+  ansible.builtin.apt:
+    update_cache: true
+    name:
+      - "clickhouse-common-static={{ clickhouse_version }}"
+      - "clickhouse-server={{ clickhouse_version }}"
+      - "clickhouse-client={{ clickhouse_version }}"
+    install_recommends: false
+  tags:
+    - clickhouse
+
+- name: Ensure the ClickHouse data directory exists
+  ansible.builtin.file:
+    path: "{{ clickhouse_data_dir }}"
+    state: directory
+    owner: clickhouse
+    group: clickhouse
+    mode: "0750"
+  tags:
+    - clickhouse
+    - configuration
+
+# config.d drops in beside the packaged config.xml rather than replacing it, so
+# a package upgrade cannot silently revert the listen address.
+- name: Configure ClickHouse listen address and ports
+  ansible.builtin.template:
+    src: listen.xml.j2
+    dest: /etc/clickhouse-server/config.d/10-lab-listen.xml
+    owner: clickhouse
+    group: clickhouse
+    mode: "0640"
+  notify:
+    - Restart clickhouse
+  tags:
+    - clickhouse
+    - configuration
+
+- name: Enable and start systemd unit for ClickHouse
+  ansible.builtin.service:
+    name: clickhouse-server.service
+    enabled: true
+    state: started
+  tags:
+    - clickhouse
+    - systemd

--- a/roles/stub_clickhouse/tasks/main.yml
+++ b/roles/stub_clickhouse/tasks/main.yml
@@ -8,7 +8,7 @@
     components:
       - main
     architectures:
-      - amd64
+      - "{{ clickhouse_arch }}"
     signed_by: "{{ clickhouse_apt_key_url }}"
   tags:
     - clickhouse

--- a/roles/stub_clickhouse/templates/listen.xml.j2
+++ b/roles/stub_clickhouse/templates/listen.xml.j2
@@ -1,0 +1,7 @@
+{# Managed by the stub_clickhouse Ansible role — local changes are overwritten. #}
+<clickhouse>
+    <listen_host>{{ clickhouse_listen_host }}</listen_host>
+    <http_port>{{ clickhouse_http_port }}</http_port>
+    <tcp_port>{{ clickhouse_tcp_port }}</tcp_port>
+    <path>{{ clickhouse_data_dir }}/</path>
+</clickhouse>


### PR DESCRIPTION
First half of Phase 3b (Deployment H — standalone ClickHouse + Akvorado flow engine). The `akvorado` role that consumes this follows in a separate PR.

## What this adds

A `stub_clickhouse` role: single-node ClickHouse from the upstream apt repository, running as a systemd service on `:8123` (HTTP) and `:9000` (native). It is the flow-storage backend for Akvorado, which creates and migrates its own schema — so this role deliberately does no schema work.

Follows the existing `stub_*` conventions (`stub_mimir`, `stub_victoriametrics`): apt/package install, config template, handler-driven restart, `GPL-3.0-or-later` meta with platforms and galaxy tags.

## Details worth reviewing

**All three packages pinned to one `clickhouse_version`.** `clickhouse-server` refuses to start against a mismatched `clickhouse-common-static`, so `clickhouse-common-static`, `clickhouse-server` and `clickhouse-client` are installed at the same version in a single task.

**Config goes in `config.d/`, not `config.xml`.** Dropping `10-lab-listen.xml` beside the packaged config means a package upgrade cannot silently revert the listen address — editing `config.xml` in place would be reverted by the maintainer-script conffile handling.

**The signing key is served from the `rpm/lts` path.** `https://packages.clickhouse.com/deb/pubkey.gpg` returns 404; the key lives at `https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key`. Both verified against the live repo, along with `26.7.1.1315` being current in `stable`.

## Stub, not production

Documented in the README and in `defaults/main.yml`: it listens on `0.0.0.0` so a separate Akvorado host can reach it, keeps the packaged `default` user with no password, and sets no quotas, resource limits or TLS. Acceptable only on the lab's private subnet — and the reason this is a `stub_*` role.

## Verification

`ansible-lint roles/stub_clickhouse` — `0 failure(s), 0 warning(s)`, profile `production` required and passed.

Not yet exercised on a live host; that happens when Deployment H is deployed end-to-end alongside the `akvorado` role.
