### PR TITLE
feat(akvorado): deploy the Akvorado flow collector against external ClickHouse

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -22,6 +22,9 @@ dependencies:
   community.postgresql: '>=4.2.0'
   community.general: '>=12.6.0'
   grafana.grafana: '>=6.1.0'
+  # Akvorado ships only as a Docker Compose stack upstream; the akvorado role
+  # drives it with community.docker.docker_compose_v2.
+  community.docker: '>=4.5.0'
 repository: https://github.com/opennms-forge/ansible-opennms
 homepage: https://github.com/opennms-forge/ansible-opennms
 issues: https://github.com/opennms-forge/ansible-opennms/issues

--- a/roles/akvorado/README.md
+++ b/roles/akvorado/README.md
@@ -1,0 +1,74 @@
+# akvorado
+
+Benchmark **stub** role: deploys the [Akvorado](https://github.com/akvorado/akvorado)
+flow collector via Docker Compose, writing to an **external** ClickHouse rather
+than the one bundled in upstream's compose stack. Not a production-grade
+Akvorado deployment.
+
+## Approach
+
+Upstream's compose stack is vendored at a pinned tag rather than reimplemented.
+That stack is more than a list of containers: the orchestrator acts as a config
+service that inlet, outlet and console fetch from at boot, tied together by a
+healthcheck dependency graph, and Traefik injects the `Remote-User` header the
+console authenticates with. Re-deriving that is more work and more risk than
+tracking it.
+
+The role therefore:
+
+1. Unpacks the release tarball to `/opt/akvorado/akvorado-<version>/`.
+2. Writes `docker/docker-compose-local.yml` — upstream's documented override
+   slot, already in the `COMPOSE_FILE` chain of the shipped `.env`, so `.env`
+   itself is left untouched.
+3. Replaces `config/akvorado.yaml` to point `clickhousedb.servers` at the
+   external node. `inlet.yaml`, `outlet.yaml` and `console.yaml` stay as
+   upstream ships them via `!include`.
+4. Brings the stack up with `community.docker.docker_compose_v2`.
+
+The bundled `clickhouse` service is parked in an unused profile — upstream's
+documented way to disable a service. Because console and outlet declare a
+healthcheck dependency on it, their `depends_on` is *replaced* (`!override`)
+rather than merged, otherwise Compose pulls the disabled service back in.
+
+## Requirements
+
+- Docker Engine with the Compose v2 plugin on the target host.
+- A reachable ClickHouse (see `stub_clickhouse`).
+
+## Variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `akvorado_version` | `2.4.1` | Upstream tag to vendor |
+| `akvorado_clickhouse_servers` | `[]` | **Required.** External ClickHouse, e.g. `["ch-benchmark-01:9000"]` |
+| `akvorado_kafka_brokers` | `[kafka:9092]` | In-stack Kafka, Akvorado's own inlet → outlet buffer |
+| `akvorado_http_port` | `8080` | Host port for the console, published from Traefik |
+| `akvorado_networks` | `192.0.2.0/24` → lab | Populates `Src/DstNetName` in the console |
+| `akvorado_demo_exporters` | `false` | Enable upstream's synthetic flow exporters |
+
+`akvorado_demo_exporters` exists because the lab's Deployment H has no load
+generator — it is how the flow path gets exercised end to end.
+
+## Ports
+
+| Port | Purpose |
+|---|---|
+| `8080/tcp` | Console (configurable) |
+| `2055/udp` | NetFlow |
+| `4739/udp` | IPFIX |
+| `6343/udp` | sFlow |
+
+## Example
+
+```yaml
+- name: Manage Akvorado
+  hosts: akvorado
+  become: true
+  roles:
+    - indigo423.opennms.common
+    - role: indigo423.opennms.akvorado
+      vars:
+        akvorado_clickhouse_servers:
+          - "ch-benchmark-01:9000"
+        akvorado_demo_exporters: true
+```

--- a/roles/akvorado/README.md
+++ b/roles/akvorado/README.md
@@ -43,7 +43,7 @@ rather than merged, otherwise Compose pulls the disabled service back in.
 | `akvorado_clickhouse_servers` | `[]` | **Required.** External ClickHouse, e.g. `["ch-benchmark-01:9000"]` |
 | `akvorado_kafka_brokers` | `[kafka:9092]` | In-stack Kafka, Akvorado's own inlet → outlet buffer |
 | `akvorado_http_port` | `8080` | Host port for the console, published from Traefik |
-| `akvorado_networks` | `192.0.2.0/24` → lab | Populates `Src/DstNetName` in the console |
+| `akvorado_networks` | `{}` | Populates `Src/DstNetName/Role` in the console; omitted from the config when empty |
 | `akvorado_demo_exporters` | `false` | Enable upstream's synthetic flow exporters |
 
 `akvorado_demo_exporters` exists because the lab's Deployment H has no load

--- a/roles/akvorado/defaults/main.yml
+++ b/roles/akvorado/defaults/main.yml
@@ -23,11 +23,15 @@ akvorado_kafka_replication_factor: 1
 # authenticates with, which is why it is kept rather than bypassed.
 akvorado_http_port: 8080
 
-# Networks reported as Src/DstNetName in the console.
-akvorado_networks:
-  192.0.2.0/24:
-    name: lab
-    role: customers
+# Networks reported as Src/DstNetName/Role in the console. Site-specific, so
+# there is no sensible default — left empty, the section is omitted entirely
+# and Akvorado simply reports no network names.
+# Example:
+#   akvorado_networks:
+#     198.51.100.0/24:
+#       name: customers
+#       role: customers
+akvorado_networks: {}
 
 # Synthetic flow exporters shipped by upstream. The lab's Deployment H has no
 # load generator, so this is how the flow path is exercised end to end.

--- a/roles/akvorado/defaults/main.yml
+++ b/roles/akvorado/defaults/main.yml
@@ -1,0 +1,34 @@
+---
+# renovate: datasource=github-tags depName=akvorado/akvorado
+akvorado_version: "2.4.1"
+akvorado_src_url: "https://github.com/akvorado/akvorado/archive/refs/tags/v{{ akvorado_version }}.tar.gz"
+akvorado_install_dir: /opt/akvorado
+
+# Where the flow schema lives. Required — the bundled ClickHouse container is
+# disabled (see templates/docker-compose-local.yml.j2) so that a dedicated
+# ClickHouse node (stub_clickhouse) can be measured on its own.
+# Example: ["ch-benchmark-01:9000"]
+akvorado_clickhouse_servers: []
+
+# Kafka stays inside the compose stack: Akvorado uses it as its own inlet ->
+# outlet buffer, not as a shared lab broker.
+akvorado_kafka_brokers:
+  - kafka:9092
+akvorado_kafka_topic: flows
+akvorado_kafka_partitions: 8
+akvorado_kafka_replication_factor: 1
+
+# Host port for the Akvorado console, published from Traefik's public
+# entrypoint. Traefik also injects the Remote-User header the console
+# authenticates with, which is why it is kept rather than bypassed.
+akvorado_http_port: 8080
+
+# Networks reported as Src/DstNetName in the console.
+akvorado_networks:
+  192.0.2.0/24:
+    name: lab
+    role: customers
+
+# Synthetic flow exporters shipped by upstream. The lab's Deployment H has no
+# load generator, so this is how the flow path is exercised end to end.
+akvorado_demo_exporters: false

--- a/roles/akvorado/handlers/main.yml
+++ b/roles/akvorado/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Restart akvorado
+  community.docker.docker_compose_v2:
+    project_src: "{{ _akvorado_project_dir }}"
+    profiles: "{{ ['demo'] if akvorado_demo_exporters else omit }}"
+    state: restarted
+    wait: true
+  tags:
+    - akvorado
+    - docker

--- a/roles/akvorado/meta/main.yml
+++ b/roles/akvorado/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  role_name: akvorado
+  author: Ronny Trommer
+  description: POC/test stub that deploys the Akvorado flow collector via Docker Compose against an external ClickHouse. Not for production use.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - akvorado
+    - flows
+    - netflow
+    - stub
+
+dependencies: []

--- a/roles/akvorado/tasks/main.yml
+++ b/roles/akvorado/tasks/main.yml
@@ -7,8 +7,11 @@
       akvorado_clickhouse_servers is empty. The bundled ClickHouse container is
       disabled, so Akvorado has nowhere to write flows. Set it to the
       stub_clickhouse host, e.g. ["ch-benchmark-01:9000"].
+  # always, not the role tag: a --tags docker or --tags configuration run would
+  # otherwise skip the guard and still template the config and start the stack,
+  # which is exactly the confusing failure this assert exists to prevent.
   tags:
-    - akvorado
+    - always
 
 - name: Create the Akvorado install directory
   ansible.builtin.file:

--- a/roles/akvorado/tasks/main.yml
+++ b/roles/akvorado/tasks/main.yml
@@ -1,0 +1,72 @@
+---
+- name: Assert an external ClickHouse is configured
+  ansible.builtin.assert:
+    that:
+      - akvorado_clickhouse_servers | length > 0
+    fail_msg: >-
+      akvorado_clickhouse_servers is empty. The bundled ClickHouse container is
+      disabled, so Akvorado has nowhere to write flows. Set it to the
+      stub_clickhouse host, e.g. ["ch-benchmark-01:9000"].
+  tags:
+    - akvorado
+
+- name: Create the Akvorado install directory
+  ansible.builtin.file:
+    path: "{{ akvorado_install_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  tags:
+    - akvorado
+
+# Unpacked per version so that bumping akvorado_version fetches the new tree
+# rather than being skipped by a version-independent creates: guard.
+- name: Unpack the Akvorado source tree for version {{ akvorado_version }}
+  ansible.builtin.unarchive:
+    src: "{{ akvorado_src_url }}"
+    dest: "{{ akvorado_install_dir }}"
+    remote_src: true
+    creates: "{{ _akvorado_project_dir }}/docker/docker-compose.yml"
+    owner: root
+    group: root
+  tags:
+    - akvorado
+
+# Upstream already lists docker-compose-local.yml in the COMPOSE_FILE chain in
+# its shipped .env, so the override applies without touching .env.
+- name: Configure the Akvorado compose override
+  ansible.builtin.template:
+    src: docker-compose-local.yml.j2
+    dest: "{{ _akvorado_project_dir }}/docker/docker-compose-local.yml"
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Restart akvorado
+  tags:
+    - akvorado
+    - configuration
+
+- name: Configure the Akvorado orchestrator
+  ansible.builtin.template:
+    src: akvorado.yaml.j2
+    dest: "{{ _akvorado_project_dir }}/config/akvorado.yaml"
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Restart akvorado
+  tags:
+    - akvorado
+    - configuration
+
+- name: Start the Akvorado stack
+  community.docker.docker_compose_v2:
+    project_src: "{{ _akvorado_project_dir }}"
+    profiles: "{{ ['demo'] if akvorado_demo_exporters else omit }}"
+    state: present
+    wait: true
+  tags:
+    - akvorado
+    - docker

--- a/roles/akvorado/templates/akvorado.yaml.j2
+++ b/roles/akvorado/templates/akvorado.yaml.j2
@@ -33,6 +33,7 @@ clickhousedb:
 clickhouse:
   orchestrator-url: http://akvorado-orchestrator:8080
   prometheus-endpoint: /metrics
+{% if akvorado_networks %}
   networks:
 {% for prefix, attrs in akvorado_networks.items() %}
     {{ prefix }}:
@@ -40,6 +41,7 @@ clickhouse:
       {{ key }}: {{ value }}
 {% endfor %}
 {% endfor %}
+{% endif %}
 
 inlet: !include "inlet.yaml"
 outlet: !include "outlet.yaml"

--- a/roles/akvorado/templates/akvorado.yaml.j2
+++ b/roles/akvorado/templates/akvorado.yaml.j2
@@ -1,0 +1,46 @@
+{# Managed by the akvorado Ansible role — local changes are overwritten. #}
+{# Replaces upstream config/akvorado.yaml. inlet/outlet/console keep their #}
+{# upstream !include files; only the parts the lab varies live here.       #}
+---
+kafka:
+  topic: {{ akvorado_kafka_topic }}
+  brokers:
+{% for broker in akvorado_kafka_brokers %}
+    - {{ broker }}
+{% endfor %}
+  topic-configuration:
+    num-partitions: {{ akvorado_kafka_partitions }}
+    replication-factor: {{ akvorado_kafka_replication_factor }}
+    config-entries:
+      segment.bytes: 1073741824
+      retention.ms: 86400000
+      cleanup.policy: delete
+      compression.type: producer
+
+geoip:
+  optional: true
+  asn-database:
+    - /usr/share/GeoIP/asn.mmdb
+  geo-database:
+    - /usr/share/GeoIP/country.mmdb
+
+clickhousedb:
+  servers:
+{% for server in akvorado_clickhouse_servers %}
+    - {{ server }}
+{% endfor %}
+
+clickhouse:
+  orchestrator-url: http://akvorado-orchestrator:8080
+  prometheus-endpoint: /metrics
+  networks:
+{% for prefix, attrs in akvorado_networks.items() %}
+    {{ prefix }}:
+{% for key, value in attrs.items() %}
+      {{ key }}: {{ value }}
+{% endfor %}
+{% endfor %}
+
+inlet: !include "inlet.yaml"
+outlet: !include "outlet.yaml"
+console: !include "console.yaml"

--- a/roles/akvorado/templates/docker-compose-local.yml.j2
+++ b/roles/akvorado/templates/docker-compose-local.yml.j2
@@ -1,0 +1,32 @@
+{# Managed by the akvorado Ansible role — local changes are overwritten. #}
+{# docker-compose-local.yml is upstream's documented override slot and is #}
+{# already part of the COMPOSE_FILE chain in the shipped .env.            #}
+---
+services:
+  # The lab measures a dedicated ClickHouse node (stub_clickhouse), so the
+  # bundled one is parked in an unused profile — upstream's documented way to
+  # disable a service. Because console and outlet declare a healthcheck
+  # dependency on it, their depends_on is replaced rather than merged, or
+  # Compose would pull the disabled service back in.
+  clickhouse:
+    profiles: [disabled]
+
+  akvorado-console:
+    depends_on: !override
+      akvorado-orchestrator:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  akvorado-outlet:
+    depends_on: !override
+      akvorado-orchestrator:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+
+  # Publish the console on the host. Traefik is kept because it injects the
+  # Remote-User header the console authenticates with.
+  traefik:
+    ports:
+      - {{ akvorado_http_port }}:8081/tcp

--- a/roles/akvorado/vars/main.yml
+++ b/roles/akvorado/vars/main.yml
@@ -1,0 +1,3 @@
+---
+# The release tarball unpacks to a version-named directory.
+_akvorado_project_dir: "{{ akvorado_install_dir }}/akvorado-{{ akvorado_version }}"


### PR DESCRIPTION
Second half of Phase 3b (Deployment H — standalone ClickHouse + Akvorado flow engine). Pairs with #125 (`stub_clickhouse`).

## Approach: vendor, don't reimplement

Upstream's compose stack is vendored at a pinned tag. I started out writing a minimal compose from scratch — the usual `stub_*` pattern — and reversed course, because that stack is more than a list of containers:

- The **orchestrator is a config service**: inlet, outlet and console all boot by fetching their configuration from `http://akvorado-orchestrator:8080`, wired with a healthcheck dependency graph.
- The **console has no auth of its own** — Traefik injects the `Remote-User`/`Remote-Name` headers it authenticates with, as a middleware.

Re-deriving that is more work and more risk than tracking it.

## How the override works

Everything lands in upstream's own extension points, so there's no forked copy to maintain:

- `docker/docker-compose-local.yml` is upstream's documented override slot and is **already in the `COMPOSE_FILE` chain of the shipped `.env`** — so `.env` is left untouched.
- Only `config/akvorado.yaml` is replaced, to point `clickhousedb.servers` at the external node. `inlet.yaml`, `outlet.yaml` and `console.yaml` stay exactly as upstream ships them, pulled in via `!include`.

**Disabling the bundled ClickHouse** uses upstream's documented mechanism — parking the service in an unused profile (their `docker-compose-local.yml` comments spell out this exact pattern). Console and outlet declare `condition: service_healthy` on it, so their `depends_on` is *replaced* with `!override` rather than merged; otherwise Compose pulls the disabled service straight back in.

## Details worth reviewing

`akvorado_clickhouse_servers` has **no default** and is asserted non-empty. With the bundled ClickHouse disabled, an unset value would otherwise surface as a confusing runtime failure inside the outlet rather than a clear play failure.

Kafka deliberately stays *inside* the compose stack — it's Akvorado's own inlet → outlet buffer, not a shared lab broker, and Deployment H has no Kafka VM.

`akvorado_demo_exporters` toggles upstream's synthetic exporters. Deployment H has no load generator, so that is how the flow path gets exercised end to end.

Adds `community.docker` to the collection dependencies — Akvorado ships only as a Compose stack upstream.

## Verification

`ansible-lint roles/akvorado` — `0 failure(s), 0 warning(s)`, profile `production` required and passed. The vendored artifact was verified against the live tag: the v2.4.1 tarball is 1.4 MB, unpacks to `akvorado-2.4.1/`, and contains `docker/docker-compose.yml`, `docker/versions.yml`, `docker/docker-compose-local.yml`, `config/akvorado.yaml` and `.env` at the paths the role expects.

**Not yet exercised on a live host.** The `profiles` + `!override depends_on` interaction is the part I would most expect to need adjustment on first deploy — it is the one behaviour I could not confirm without a running Compose. That happens when Deployment H is deployed end to end.
