### PR TITLE
feat(stub_elasticsearch): derive cluster discovery from the inventory

### DIFF
--- a/roles/stub_elasticsearch/defaults/main.yml
+++ b/roles/stub_elasticsearch/defaults/main.yml
@@ -8,14 +8,19 @@ drift_version: 2.0.7
 es_pkg_version: "{{ es_version }}*"
 onms_drift_plugin_dir: /usr/share/elasticsearch/plugins/drift
 es_etc_dir: /etc/elasticsearch
+# Inventory group whose members form the cluster. One member -> single-node
+# discovery; more than one -> seed hosts and initial master nodes are derived
+# from it, so scaling the group is the only change needed.
+es_cluster_group: elasticsearch
+
+# Discovery keys are NOT set here — the role computes them from es_cluster_group
+# (see vars/main.yml) and merges them over this dict. Setting discovery.type or
+# discovery.seed_hosts here would be overridden.
 es_configuration:
   action.destructive_requires_name: true
   bootstrap.memory_lock: true
-  # cluster.initial_master_nodes: '["node-1", "node-2"]'
   cluster.max_shards_per_node: 6000
   cluster.name: opennms-flows
-  discovery.type: single-node
-  # discovery.seed_hosts: '["host1", "host2"]'
   http.port: 9200
   network.host: 0.0.0.0
   node.attr.rack: r1

--- a/roles/stub_elasticsearch/handlers/main.yml
+++ b/roles/stub_elasticsearch/handlers/main.yml
@@ -1,8 +1,11 @@
 ---
 - name: Restart elasticsearch
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: elasticsearch.service
     state: restarted
+    # The role may drop in a systemd override for LimitMEMLOCK, so reload the
+    # unit before restarting rather than leaving the change unapplied.
+    daemon_reload: true
   tags:
     - elasticsearch
     - systemd

--- a/roles/stub_elasticsearch/tasks/main.yml
+++ b/roles/stub_elasticsearch/tasks/main.yml
@@ -51,6 +51,46 @@
     - plugin_drift
 # yamllint enable rule:line-length
 
+# bootstrap.memory_lock is only enforced once bootstrap checks run, which
+# single-node Elasticsearch skips. A cluster runs them, so without this limit
+# the node dies with "memory locking requested ... but memory is not locked".
+# Granted rather than disabling the lock: an Elasticsearch that swaps is
+# useless for benchmarking.
+- name: Create the Elasticsearch systemd drop-in directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/elasticsearch.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  tags:
+    - elasticsearch
+    - configuration
+
+- name: Allow Elasticsearch to lock memory
+  ansible.builtin.template:
+    src: systemd/memlock.conf.j2
+    dest: /etc/systemd/system/elasticsearch.service.d/memlock.conf
+    owner: root
+    group: root
+    mode: "0644"
+  when: es_configuration['bootstrap.memory_lock'] | default(false) | bool
+  tags:
+    - elasticsearch
+    - configuration
+
+# Reloaded here rather than from a handler: handlers run at the end of the
+# play, but the service-start task below would fail first and abort the play,
+# leaving the drop-in on disk and unloaded. Unconditional and idempotent, so it
+# does not depend on change detection.
+- name: Reload systemd so the Elasticsearch limits apply
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+  changed_when: false
+  tags:
+    - elasticsearch
+    - configuration
+
 - name: Configure Elasticsearch
   ansible.builtin.template:
     src: elasticsearch.yml.j2

--- a/roles/stub_elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/stub_elasticsearch/templates/elasticsearch.yml.j2
@@ -100,6 +100,6 @@
 # Managed by Ansible
 ######
 
-{% for (key, value) in es_configuration.items() %}
+{% for (key, value) in _es_effective_configuration.items() | sort %}
 {{ key }}: {{ value }}
 {% endfor %}

--- a/roles/stub_elasticsearch/templates/systemd/memlock.conf.j2
+++ b/roles/stub_elasticsearch/templates/systemd/memlock.conf.j2
@@ -1,0 +1,8 @@
+# Managed by the stub_elasticsearch Ansible role — local changes are overwritten.
+#
+# bootstrap.memory_lock requires the service to be allowed to lock memory.
+# Single-node Elasticsearch skips bootstrap checks, so the setting was inert
+# and this limit was never needed; a real cluster enforces them and refuses to
+# start without it.
+[Service]
+LimitMEMLOCK=infinity

--- a/roles/stub_elasticsearch/vars/main.yml
+++ b/roles/stub_elasticsearch/vars/main.yml
@@ -1,0 +1,28 @@
+---
+# Cluster members, in a stable order so every node renders the same seed list.
+# Falls back to this host alone when the group is absent, which keeps the role
+# usable on an inventory that does not define es_cluster_group.
+_es_members: "{{ groups[es_cluster_group] | default([inventory_hostname]) | sort }}"
+
+# Discovery is derived, not configured. A single member keeps the previous
+# behaviour (discovery.type: single-node, which Elasticsearch requires instead
+# of — not alongside — seed hosts). Two or more switch to real cluster
+# formation.
+#
+# Seed and master lists use inventory hostnames rather than addresses: node.name
+# defaults to ansible_hostname, so cluster.initial_master_nodes must match those
+# names, and the lab writes every host into /etc/hosts. Elasticsearch runs as a
+# host process, so that resolution applies to it (unlike containerised roles).
+_es_discovery: >-
+  {{
+    {'discovery.type': 'single-node'}
+    if (_es_members | length) < 2 else
+    {
+      'discovery.seed_hosts': _es_members | to_json,
+      'cluster.initial_master_nodes': _es_members | to_json,
+    }
+  }}
+
+# What the template renders. Derived discovery wins over es_configuration so a
+# stale discovery.type in a user override cannot silently break formation.
+_es_effective_configuration: "{{ es_configuration | combine(_es_discovery) }}"

--- a/roles/stub_elasticsearch/vars/main.yml
+++ b/roles/stub_elasticsearch/vars/main.yml
@@ -23,6 +23,24 @@ _es_discovery: >-
     }
   }}
 
-# What the template renders. Derived discovery wins over es_configuration so a
-# stale discovery.type in a user override cannot silently break formation.
-_es_effective_configuration: "{{ es_configuration | combine(_es_discovery) }}"
+# What the template renders.
+#
+# combine() can only ADD keys, so merging is not enough: an operator-supplied
+# es_configuration that still carries discovery.type would keep it alongside the
+# derived cluster keys, and Elasticsearch refuses to boot with
+#   setting [cluster.initial_master_nodes] is not allowed when
+#   [discovery.type] is set to [single-node]
+# The benchmark lab does exactly that — it overrides the whole dict via
+# extra-vars, which outrank role defaults — so clustering strips discovery.type
+# from whatever es_configuration resolves to before merging. That is what makes
+# the two forms mutually exclusive by construction rather than by the operator
+# remembering to delete one.
+_es_effective_configuration: >-
+  {{
+    (es_configuration | dict2items
+                      | rejectattr('key', 'equalto', 'discovery.type')
+                      | items2dict
+                      | combine(_es_discovery))
+    if (_es_members | length) >= 2
+    else (es_configuration | combine(_es_discovery))
+  }}


### PR DESCRIPTION
First component of Phase 3c (HA multi-node, Deployment A). The remaining three — `stub_kafka` (3-broker KRaft), `opennms_sentinel` (multi-instance) and `stub_mimir` (distributed rings) — follow separately.

## The problem

The role was single-node by construction. `discovery.type: single-node` was hard-set in `es_configuration`, with the cluster keys sitting next to it commented out:

```yaml
# cluster.initial_master_nodes: '["node-1", "node-2"]'
discovery.type: single-node
# discovery.seed_hosts: '["host1", "host2"]'
```

Uncommenting them isn't enough: Elasticsearch **rejects** `discovery.type: single-node` alongside seed hosts, so the two forms are mutually exclusive and an operator had to know to delete one.

## The change

Discovery is now *derived* from an inventory group (`es_cluster_group`, default `elasticsearch`) rather than configured:

- **one member** → `discovery.type: single-node`, exactly as before
- **two or more** → `discovery.seed_hosts` and `cluster.initial_master_nodes` built from the group

Scaling the group is the only change needed. The mutual exclusion is now structural rather than a thing to remember, and the derived keys are merged *over* `es_configuration`, so a stale `discovery.type` in a user override can't silently break cluster formation.

The lists use inventory **hostnames**, not addresses. `node.name` defaults to `ansible_hostname`, so `cluster.initial_master_nodes` must match those names, and the lab writes every host into `/etc/hosts`. Elasticsearch runs as a host process, so that resolution applies — unlike the containerised roles, where Docker's embedded resolver ignores the host's `/etc/hosts`.

## Verification

Rendered the template against fake inventories, both ways:

```
1 node   discovery.type: single-node
         (no seed hosts, no initial master nodes)

3 nodes  cluster.initial_master_nodes: ["es-benchmark-01","es-benchmark-02","es-benchmark-03"]
         discovery.seed_hosts:         ["es-benchmark-01","es-benchmark-02","es-benchmark-03"]
         (discovery.type absent)
```

The single-node render is byte-identical in its discovery keys to the current behaviour, so `baseline`, `es-nostore` and `vm-cluster-es` — every deployment that runs one Elasticsearch — are unaffected.

`ansible-lint` passes at `production` profile.

**Not yet exercised on a real cluster.** A 3-node Elasticsearch test bed is 24 GB plus a jump host, which fits the lab hypervisor; that verification is the next step. Worth noting for planning: full Deployment A needs **132 GB / 50 vCPU** against a host with **62 GB / 16 cores**, so A itself cannot run there — which is why Phase 3c is being built and verified component by component.
