### PR TITLE
feat(opennms_sentinel): default the broker list from the inventory group

### DIFF
--- a/roles/opennms_sentinel/defaults/main.yml
+++ b/roles/opennms_sentinel/defaults/main.yml
@@ -32,6 +32,19 @@ opennms_sentinel_controller:
   id: "{{ ansible_facts['machine_id'] if ansible_facts['machine_id'] is defined else inventory_hostname }}"
   location: ANSIBLE_UNSET_SENTINEL_LOCATION
 
+# Inventory group holding the Kafka brokers, used to default
+# bootstrap.servers below. Empty or absent falls back to localhost:9092.
+sentinel_kafka_group: message_broker
+sentinel_kafka_port: 9092
+
 opennms_sentinel_kafka:
-  "bootstrap.servers": localhost:9092
+  # Defaulted from sentinel_kafka_group rather than hard-coded: Sentinel and
+  # Kafka are separate nodes in every topology that runs a Sentinel, so
+  # localhost:9092 is never right there. Being a default, an operator-supplied
+  # opennms_sentinel_kafka still wins outright.
+  "bootstrap.servers": "{{ _sentinel_bootstrap_servers }}"
+  # One shared group is what makes several Sentinels split the flow workload:
+  # Kafka assigns partitions across the consumers in a group, so instances
+  # divide the load rather than each processing every record. Giving them
+  # distinct group ids would duplicate the work instead.
   "group.id": OpenNMS

--- a/roles/opennms_sentinel/vars/main.yml
+++ b/roles/opennms_sentinel/vars/main.yml
@@ -1,0 +1,12 @@
+---
+# Brokers in a stable order, so every Sentinel renders the same bootstrap list.
+_sentinel_brokers: "{{ groups[sentinel_kafka_group] | default([]) | sort }}"
+
+# host-01:9092,host-02:9092,... Falls back to the previous hard-coded value
+# when no broker group is present, so an inventory without one is unaffected.
+# Sentinel runs as a host process, so the lab's /etc/hosts resolves these names
+# — unlike the containerised roles, where Docker's resolver ignores that file.
+_sentinel_bootstrap_servers: >-
+  {{ (_sentinel_brokers | map('regex_replace', '$', ':' ~ sentinel_kafka_port) | join(','))
+     if (_sentinel_brokers | length) > 0
+     else 'localhost:' ~ sentinel_kafka_port }}


### PR DESCRIPTION
Third component of Phase 3c, and much the smallest — most of what multi-instance needs was **already true**.

## What was already right

- **`opennms_sentinel_controller.id`** derives per host from `machine_id`, so instances are distinct with no change.
- **The shared `group.id` is not an oversight, it is the mechanism.** Kafka assigns partitions across consumers in a group, so several Sentinels *split* the flow workload rather than each processing every record. Distinct group ids would duplicate the work.

## What was wrong

`bootstrap.servers` was hard-coded to `localhost:9092`. Sentinel and Kafka are separate nodes in every topology that runs a Sentinel, so that value is never correct there. It now defaults to the brokers in `sentinel_kafka_group`.

## A deliberately different choice from #131

In `stub_kafka` I made derived settings **win over** the operator's dict, but only at 2+ members — because this lab supplies a deliberate `kafka_server_properties` that clustering has to override.

Here it is a plain **default** instead. Nothing supplies `opennms_sentinel_kafka` at all — `grep sentinel` in the benchmark's `opennms-lab-vars.yml` returns nothing, because no current deployment runs a Sentinel. With no operator intent to protect, a default is the least surprising form: an explicit override still wins outright.

## Verification

```
no broker group   bootstrap.servers = localhost:9092        (unchanged)
3 brokers         bootstrap.servers = kafka-benchmark-01:9092,
                                      kafka-benchmark-02:9092,
                                      kafka-benchmark-03:9092
controller ids    sen-benchmark-01 / -02 / -03  (distinct)
group.id          OpenNMS  (shared)
```

`ansible-lint` passes at `production` profile.

**Not verified on a live cluster**, and worth being explicit about why: a meaningful Sentinel bed needs Core, PostgreSQL, Kafka and Elasticsearch alongside it, so confirming that instances genuinely partition rather than duplicate the flow workload is a separate and much heavier exercise than the Elasticsearch and Kafka beds were. The claim above rests on Kafka consumer-group semantics, not on an observed run.