### PR TITLE
feat(stub_mimir): distributed mode with shared object storage

### DIFF
--- a/roles/stub_mimir/defaults/main.yml
+++ b/roles/stub_mimir/defaults/main.yml
@@ -13,3 +13,26 @@ mimir_ingestion_rate: 1000000
 mimir_ingestion_burst_size: 2000000
 mimir_max_global_series_per_user: 0
 mimir_max_global_series_per_metric: 0
+
+# Inventory group whose members form the cluster. One member keeps the
+# single-node monolithic behaviour; more than one switches the rings to
+# memberlist and scales replication.
+mimir_cluster_group: mimir
+mimir_memberlist_port: 7946
+
+# Shared object storage. Multi-node Mimir cannot use the filesystem backend:
+# every component must see the same blocks, and a per-node directory is not a
+# shared store. Set the endpoint to switch blocks/ruler/alertmanager storage to
+# S3; left empty, storage stays on the filesystem (correct only for one node).
+#
+# Deliberately generic rather than naming a product. Mimir talks S3, so this
+# works against AWS S3, MinIO, RustFS or anything else that does — the lab
+# chooses the implementation, the role does not.
+mimir_s3_endpoint: ""
+mimir_s3_bucket_blocks: mimir-blocks
+mimir_s3_bucket_ruler: mimir-ruler
+mimir_s3_bucket_alertmanager: mimir-alertmanager
+mimir_s3_access_key_id: ""
+mimir_s3_secret_access_key: ""
+# Lab object storage is typically plain HTTP on a private subnet.
+mimir_s3_insecure: true

--- a/roles/stub_mimir/defaults/main.yml
+++ b/roles/stub_mimir/defaults/main.yml
@@ -20,6 +20,19 @@ mimir_max_global_series_per_metric: 0
 mimir_cluster_group: mimir
 mimir_memberlist_port: 7946
 
+# Address each node advertises into the rings and to memberlist peers.
+#
+# Mimir's ring lifecycler defaults to finding an address on interfaces
+# [eth0, en0]. Modern predictable interface names (enp1s0, ...) match neither,
+# so a clustered node dies at startup with "no useable address found for
+# interfaces [eth0 en0] / invalid ring lifecycler config". Single-node never hit
+# this because in-memory rings need no advertisable address.
+#
+# Set explicitly rather than by listing interface names, which would only move
+# the guess from Mimir's list to ours. Defaults to the inventory's management
+# address; leave empty to fall back to Mimir's own interface detection.
+mimir_instance_addr: "{{ lab_mgmt_ip | default('') }}"
+
 # Shared object storage. Multi-node Mimir cannot use the filesystem backend:
 # every component must see the same blocks, and a per-node directory is not a
 # shared store. Set the endpoint to switch blocks/ruler/alertmanager storage to

--- a/roles/stub_mimir/tasks/main.yml
+++ b/roles/stub_mimir/tasks/main.yml
@@ -1,4 +1,21 @@
 ---
+# A cluster cannot use the filesystem backend: each node would write blocks to
+# its own disk, so ingesters, store-gateways and compactors would never see the
+# same data. Caught here rather than as confusing query gaps later.
+- name: Assert clustered Mimir has shared object storage
+  ansible.builtin.assert:
+    that:
+      - mimir_s3_endpoint | length > 0
+    fail_msg: >-
+      {{ _mimir_members | length }} Mimir nodes are configured but
+      mimir_s3_endpoint is empty. Multi-node Mimir needs a shared object store;
+      the filesystem backend is per-node and is only correct for a single node.
+      Point mimir_s3_endpoint at an S3-compatible endpoint and set
+      mimir_s3_access_key_id / mimir_s3_secret_access_key.
+  when: _mimir_clustered | bool
+  tags:
+    - always
+
 - name: Install a Mimir package
   ansible.builtin.apt:
     deb: '{{ mimir_pkg_url }}'

--- a/roles/stub_mimir/templates/config.yml.j2
+++ b/roles/stub_mimir/templates/config.yml.j2
@@ -21,6 +21,10 @@ limits:
 {% if _mimir_clustered | bool %}
 memberlist:
   bind_port: {{ mimir_memberlist_port }}
+{% if mimir_instance_addr | length > 0 %}
+  advertise_addr: {{ mimir_instance_addr }}
+  advertise_port: {{ mimir_memberlist_port }}
+{% endif %}
   join_members:
 {% for member in _mimir_members %}
     - {{ member }}:{{ mimir_memberlist_port }}
@@ -72,23 +76,56 @@ alertmanager_storage:
 ingester:
   ring:
     replication_factor: {{ _mimir_replication_factor }}
+{% if _mimir_clustered | bool and mimir_instance_addr | length > 0 %}
+    instance_addr: {{ mimir_instance_addr }}
+{% endif %}
     kvstore:
       store: {{ _mimir_kvstore }}
 distributor:
   ring:
+{% if _mimir_clustered | bool and mimir_instance_addr | length > 0 %}
+    instance_addr: {{ mimir_instance_addr }}
+{% endif %}
     kvstore:
       store: {{ _mimir_kvstore }}
 store_gateway:
   sharding_ring:
     replication_factor: {{ _mimir_replication_factor }}
+{% if _mimir_clustered | bool and mimir_instance_addr | length > 0 %}
+    instance_addr: {{ mimir_instance_addr }}
+{% endif %}
     kvstore:
       store: {{ _mimir_kvstore }}
 compactor:
   data_dir: {{ mimir_data_dir }}/compactor
   sharding_ring:
+{% if _mimir_clustered | bool and mimir_instance_addr | length > 0 %}
+    instance_addr: {{ mimir_instance_addr }}
+{% endif %}
     kvstore:
       store: {{ _mimir_kvstore }}
 ruler:
   ring:
+{% if _mimir_clustered | bool and mimir_instance_addr | length > 0 %}
+    instance_addr: {{ mimir_instance_addr }}
+{% endif %}
     kvstore:
       store: {{ _mimir_kvstore }}
+{% if _mimir_clustered | bool and mimir_instance_addr | length > 0 %}
+# The query-frontend and alertmanager resolve their own addresses too, by the
+# same interface probing as the rings — so they need telling as well, or Mimir
+# fails later in startup with "failed to get frontend address".
+#
+# "address", not "instance_addr": the query-frontend's config type
+# (frontend.CombinedFrontendConfig) has no instance_addr field and rejects it
+# outright, even though a -query-frontend.instance-addr flag exists. Verified
+# against the running binary; instance_interface_names also works but would
+# only move the guess from Mimir's interface list to ours.
+frontend:
+  address: {{ mimir_instance_addr }}
+alertmanager:
+  sharding_ring:
+    instance_addr: {{ mimir_instance_addr }}
+    kvstore:
+      store: {{ _mimir_kvstore }}
+{% endif %}

--- a/roles/stub_mimir/templates/config.yml.j2
+++ b/roles/stub_mimir/templates/config.yml.j2
@@ -1,6 +1,14 @@
-# Managed by Ansible (indigo423.opennms.stub_mimir) — single-node monolithic.
-# Minimal functional config: replication_factor 1 + in-memory rings (single
+{# Keep every Jinja tag at column 0: Ansible templates with trim_blocks but   #}
+{# not lstrip_blocks, so leading whitespace on a tag line survives into the   #}
+{# output and would corrupt this file's indentation.                          #}
+# Managed by Ansible (indigo423.opennms.stub_mimir).
+{% if _mimir_clustered | bool %}
+# Clustered: memberlist rings across {{ _mimir_members | length }} members,
+# replication_factor {{ _mimir_replication_factor }}, shared object storage.
+{% else %}
+# Single-node monolithic: replication_factor 1 + in-memory rings (single
 # process) + per-component filesystem storage (distinct dirs, no overlap).
+{% endif %}
 multitenancy_enabled: false
 server:
   http_listen_port: {{ mimir_http_port }}
@@ -10,42 +18,77 @@ limits:
   ingestion_burst_size: {{ mimir_ingestion_burst_size }}
   max_global_series_per_user: {{ mimir_max_global_series_per_user }}
   max_global_series_per_metric: {{ mimir_max_global_series_per_metric }}
+{% if _mimir_clustered | bool %}
+memberlist:
+  bind_port: {{ mimir_memberlist_port }}
+  join_members:
+{% for member in _mimir_members %}
+    - {{ member }}:{{ mimir_memberlist_port }}
+{% endfor %}
+{% endif %}
 blocks_storage:
-  backend: filesystem
+  backend: {{ _mimir_storage_backend }}
+{% if _mimir_storage_backend == 's3' %}
+  s3:
+    endpoint: {{ mimir_s3_endpoint }}
+    bucket_name: {{ mimir_s3_bucket_blocks }}
+    access_key_id: {{ mimir_s3_access_key_id }}
+    secret_access_key: {{ mimir_s3_secret_access_key }}
+    insecure: {{ mimir_s3_insecure | bool | lower }}
+{% else %}
   filesystem:
     dir: {{ mimir_data_dir }}/blocks
+{% endif %}
   tsdb:
     dir: {{ mimir_data_dir }}/tsdb
   bucket_store:
     sync_dir: {{ mimir_data_dir }}/tsdb-sync
 ruler_storage:
-  backend: filesystem
+  backend: {{ _mimir_storage_backend }}
+{% if _mimir_storage_backend == 's3' %}
+  s3:
+    endpoint: {{ mimir_s3_endpoint }}
+    bucket_name: {{ mimir_s3_bucket_ruler }}
+    access_key_id: {{ mimir_s3_access_key_id }}
+    secret_access_key: {{ mimir_s3_secret_access_key }}
+    insecure: {{ mimir_s3_insecure | bool | lower }}
+{% else %}
   filesystem:
     dir: {{ mimir_data_dir }}/ruler
+{% endif %}
 alertmanager_storage:
-  backend: filesystem
+  backend: {{ _mimir_storage_backend }}
+{% if _mimir_storage_backend == 's3' %}
+  s3:
+    endpoint: {{ mimir_s3_endpoint }}
+    bucket_name: {{ mimir_s3_bucket_alertmanager }}
+    access_key_id: {{ mimir_s3_access_key_id }}
+    secret_access_key: {{ mimir_s3_secret_access_key }}
+    insecure: {{ mimir_s3_insecure | bool | lower }}
+{% else %}
   filesystem:
     dir: {{ mimir_data_dir }}/alertmanager
+{% endif %}
 ingester:
   ring:
-    replication_factor: 1
+    replication_factor: {{ _mimir_replication_factor }}
     kvstore:
-      store: inmemory
+      store: {{ _mimir_kvstore }}
 distributor:
   ring:
     kvstore:
-      store: inmemory
+      store: {{ _mimir_kvstore }}
 store_gateway:
   sharding_ring:
-    replication_factor: 1
+    replication_factor: {{ _mimir_replication_factor }}
     kvstore:
-      store: inmemory
+      store: {{ _mimir_kvstore }}
 compactor:
   data_dir: {{ mimir_data_dir }}/compactor
   sharding_ring:
     kvstore:
-      store: inmemory
+      store: {{ _mimir_kvstore }}
 ruler:
   ring:
     kvstore:
-      store: inmemory
+      store: {{ _mimir_kvstore }}

--- a/roles/stub_mimir/vars/main.yml
+++ b/roles/stub_mimir/vars/main.yml
@@ -1,0 +1,14 @@
+---
+# Cluster members in a stable order, so every node renders the same join list.
+_mimir_members: "{{ groups[mimir_cluster_group] | default([inventory_hostname]) | sort }}"
+_mimir_clustered: "{{ (_mimir_members | length) > 1 }}"
+
+# inmemory rings only work inside one process. A cluster has to gossip, so the
+# kvstore switches to memberlist and every node joins the same peer list.
+_mimir_kvstore: "{{ 'memberlist' if (_mimir_members | length) > 1 else 'inmemory' }}"
+
+# Mimir refuses to start when replication exceeds the number of ingesters.
+_mimir_replication_factor: "{{ [_mimir_members | length, 3] | min }}"
+
+# S3 when an endpoint is configured, filesystem otherwise.
+_mimir_storage_backend: "{{ 's3' if (mimir_s3_endpoint | length > 0) else 'filesystem' }}"


### PR DESCRIPTION
Fourth and last component of Phase 3c, and the one that needed a **design decision** rather than just derivation.

## Why this one was different

Phase 3a deliberately configured this role single-node monolithic — `replication_factor: 1`, in-memory rings, per-component **filesystem** storage. None of that survives more than one node:

- in-memory rings only work inside one process;
- the filesystem backend is per-node, so each node would write blocks to its own disk and ingesters, store-gateways and compactors would never see the same data.

So unlike Elasticsearch, Kafka and Sentinel, this could not be solved by deriving values from the inventory. It needed shared storage to exist.

## The design

Rings switch to `memberlist` with every member in `join_members`; replication tracks the member count capped at 3 (Mimir refuses to start when replication exceeds the ingester count).

**Storage is generic, not a product.** Mimir speaks S3, so `mimir_s3_endpoint` works against AWS S3, MinIO, RustFS or anything else. The lab picks the implementation; the role does not.

That also keeps this role inside the collection's own scope rule. OpenNMS writes to Mimir, so Mimir belongs here — but the object store Mimir happens to sit on is a lab choice, and the RustFS role that provides it lives in the benchmark repo. Welding a specific object store into the collection would have stretched the wire rule on its first genuinely ambiguous case.

**Backend selection is orthogonal to clustering:** S3 when an endpoint is set, filesystem otherwise, so a single node can use object storage too. The one combination that cannot work — clustered with no endpoint — is asserted, rather than left to surface later as unexplained gaps in query results.

## Verification

Rendered both shapes and parsed them as YAML:

```
1 node    blocks: filesystem /var/lib/mimir/blocks
          ingester: RF 1, kvstore inmemory
          memberlist: absent                                   <- unchanged

3 nodes   blocks: s3, bucket mimir-blocks @ rustfs-benchmark-01:9000
          ingester: RF 3, kvstore memberlist
          memberlist join: mimir-benchmark-01/-02/-03 :7946
          ruler / alertmanager: mimir-ruler / mimir-alertmanager
```

`mimir-single` — already proven end to end in Phase 3a — renders exactly as before.

`ansible-lint` passes at `production` profile.

**Not yet exercised on a real cluster.** That needs an S3 endpoint standing alongside three Mimir nodes; a `mimir-cluster-min` test bed (3 Mimir + 1 object store + jump host ≈ 36 GB) fits the lab hypervisor and is the next step.