### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to the `indigo423.opennms` collection are documented in this
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each entry below is a short index; the corresponding GitHub release contains the full notes including the Component Versions table and upgrade instructions.
 
+## [0.7.0] - 2026-07-28
+
+Multi-node support for the stub infrastructure roles and Sentinel. Every role
+derives its cluster shape from inventory group membership, so scaling a
+deployment is the only change required, and a single-member group renders
+exactly as before — `baseline`, `es-nostore`, `vm-cluster-es`, `mimir-single`
+and `vm-single` are unaffected.
+
+### Added
+- `stub_elasticsearch`: derive discovery from `es_cluster_group` — `discovery.type: single-node` for one member, `discovery.seed_hosts` and `cluster.initial_master_nodes` for two or more. The two forms are mutually exclusive in Elasticsearch, so clustering strips `discovery.type` from whatever `es_configuration` resolves to rather than assuming it is absent (#130).
+- `stub_kafka`: form a KRaft cluster from `kafka_cluster_group` — positional `node.id`, full `controller.quorum.voters`, per-broker `advertised.listeners`, and replication scaled to the member count capped at 3. The cluster ID is established once for the cluster and reused from disk on re-runs; previously each host generated its own, so brokers would have formed separate clusters and refused to join with `INCONSISTENT_CLUSTER_ID`. Derived values apply only at two or more members, leaving deliberate single-broker configuration untouched (#131).
+- `opennms_sentinel`: default `bootstrap.servers` from `sentinel_kafka_group` instead of `localhost:9092`, which is never correct when Sentinel and Kafka are separate nodes. Controller ids already derive per host, and the shared `group.id` is what makes several Sentinels split the flow workload rather than each processing every record (#132).
+- `stub_mimir`: distributed mode — memberlist rings across the member group, replication scaled to the member count, and generic S3 blocks/ruler/alertmanager storage via `mimir_s3_endpoint`, which works against AWS S3, MinIO, RustFS or anything else that speaks S3. Clustered with no endpoint is asserted rather than left to surface as unexplained query gaps, because the filesystem backend is per-node and cannot be shared (#133).
+
+### Fixed
+- `stub_elasticsearch`: grant `LimitMEMLOCK` via a systemd drop-in when `bootstrap.memory_lock` is set. Single-node Elasticsearch skips bootstrap checks, so the setting had been inert; a cluster enforces them and refused to start (#130).
+- `stub_mimir`: give clustered components an explicit `instance_addr`, and the query-frontend an `address`. Mimir resolves its own address by probing interfaces `[eth0, en0]`, which modern predictable names do not match (#133).
+- `galaxy.yml`: exclude gitignored working directories from `build_ignore`, so they no longer reach the published artifact (#123).
+
+### Changed
+- CI runs `ansible-lint` on pull requests, with pushes scoped to `main` (#124).
+
 ## [0.6.0] - 2026-07-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,10 +74,14 @@ them, that is the signal.
 
 **Stub infrastructure roles** (POC/testing only, not production):
 - `stub_pgsql` — PostgreSQL 18 with OpenNMS database/user
-- `stub_kafka` — Kafka 4.2.0 in KRaft mode
-- `stub_elasticsearch` — Elasticsearch for flow data
-- `stub_mimir` — Grafana Mimir 3.0.4, single-node monolithic mode
+- `stub_kafka` — Kafka 4.2.0 in KRaft mode; single broker, or a cluster derived from `kafka_cluster_group`
+- `stub_elasticsearch` — Elasticsearch for flow data; single node, or a cluster derived from `es_cluster_group`
+- `stub_mimir` — Grafana Mimir 3.0.4; single-node monolithic, or distributed via memberlist with shared S3 storage (`mimir_s3_endpoint`)
 - `stub_victoriametrics` — VictoriaMetrics 1.148.0, single-node
+
+Multi-node roles derive their cluster shape from inventory group membership, so
+scaling a deployment is the only change needed. A single-member group renders
+exactly as it did before clustering was added.
 
 **External collection roles** (replacing stubs where mature alternatives exist):
 - `grafana.grafana.grafana` — Grafana 12.x (replaces `stub_grafana`); configured via `inventory/group_vars/grafana/vars.yml`

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: indigo423
 name: opennms
-version: 0.6.0
+version: 0.7.0
 readme: README.md
 authors:
   - Ronny Trommer <ronny@no42.org>


### PR DESCRIPTION
Release-prep for **v0.7.0**. Per `RELEASING.md`, `main` must carry the `galaxy.yml` bump and a matching `CHANGELOG.md` entry before the tag — `galaxy-release.yml` refuses to publish if they disagree.

## Why MINOR

New opt-in capability on existing roles; no roles added or removed since v0.6.0.

## What ships

Multi-node support for the stub infrastructure roles and Sentinel. Each derives its cluster shape from inventory group membership, so scaling a deployment is the only change required.

- `stub_elasticsearch` — derived discovery; clustering *strips* `discovery.type` rather than assuming it absent, because the two forms are mutually exclusive and this lab supplies its own `es_configuration` (#130)
- `stub_kafka` — KRaft cluster with a **shared cluster ID**; each host previously minted its own, so brokers would have formed separate clusters and refused to join (#131)
- `opennms_sentinel` — `bootstrap.servers` defaulted from the broker group instead of `localhost:9092` (#132)
- `stub_mimir` — memberlist rings and **generic S3** storage, so Mimir HA works against AWS S3, MinIO or RustFS alike (#133)

Plus two fixes that only a real cluster exposes: Elasticsearch's `LimitMEMLOCK` (inert until bootstrap checks run) and Mimir's explicit `instance_addr`/`address` (it probes `[eth0, en0]`, which predictable interface names don't match).

## Backward compatibility

A single-member group renders exactly as before. That isn't just asserted — `baseline` was deployed against this code: Elasticsearch kept `discovery.type: single-node` with no `initial_master_nodes`, Kafka kept the lab's explicit `advertised.listeners`, `node.id=1` and RF 1, and OpenNMS came up with `login.jsp` 200.

## Two deliberate omissions

**The changelog says nothing about `akvorado` or `stub_clickhouse`.** Both were added (#125, #126) and withdrawn (#129) inside this unreleased range, so they never appeared in any release. Listing them as added-then-removed would only confuse consumers who never saw them.

**No claim that Sentinel instances partition rather than duplicate flow work.** They're verified active with distinct controller ids and a derived broker list; the partitioning property rests on Kafka consumer-group semantics and hasn't been observed under sustained load.

## Verified before tagging

All four roles were exercised on real infrastructure, not just rendered:

```
Elasticsearch  green, 3 nodes, primaries+replicas across all three
Kafka          3-broker KRaft quorum, one shared cluster ID, RF-3 topic
Mimir          3-node ring, ready 200, backed by S3 (RustFS)
Sentinel       3 active, distinct machine_id-derived ids,
               bootstrap.servers listing all three brokers
```

`ansible-lint` passes at `production` profile. `CLAUDE.md` role descriptions updated — `stub_mimir` was still documented as single-node-only. No component versions changed, so the Key Versions table is untouched.

Once merged, the tag follows and the benchmark's pin moves off `583efae # v0.6.0`.